### PR TITLE
Fixed Q_OS_UNIX definition. Required for Linux build

### DIFF
--- a/src/ui/apmtoolbar.cpp
+++ b/src/ui/apmtoolbar.cpp
@@ -61,7 +61,7 @@ APMToolBar::APMToolBar(QWidget *parent):
 #ifdef Q_OS_MAC
     rootObject()->setProperty("rowSpacerSize", QVariant(3));
     rootObject()->setProperty("linkDeviceSize", QVariant(105));
-#elif Q_OS_UNIX
+#elif defined(Q_OS_UNIX)
     rootObject()->setProperty("rowSpacerSize", QVariant(3));
     rootObject()->setProperty("linkDeviceSize", QVariant(100));
 #else


### PR DESCRIPTION
GCC doesn't seem to like non-explicit #elif XXX.
Other than this, apm_planner compiles quite nicely under Ubuntu now.
