### PR TITLE
Log to KML button

### DIFF
--- a/src/output/kmlcreator.cc
+++ b/src/output/kmlcreator.cc
@@ -171,11 +171,13 @@ Placemark* KMLCreator::lastPlacemark() {
     return (m_placemarks.size() > 0)? m_placemarks[m_placemarks.size()-1]: 0;
 }
 
-void KMLCreator::finish(bool kmz) {
+QString KMLCreator::finish(bool kmz) {
     if(m_filename.isEmpty()) {
         QLOG_DEBUG() << "No filename specified. Call start() first.";
-        return;
+        return "";
     }
+
+    QString result(m_filename);
 
     QLOG_DEBUG() << "write kml to " << m_filename;
 
@@ -183,7 +185,7 @@ void KMLCreator::finish(bool kmz) {
 
     if(!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QLOG_ERROR() << "Unable to write to " << m_filename;
-        return;
+        return "";
     }
 
     QXmlStreamWriter writer;
@@ -285,6 +287,8 @@ void KMLCreator::finish(bool kmz) {
             kmzFile = fn + ".kmz";
         }
 
+        result = kmzFile;
+
         QStringList params;
 
         params << file.fileName();
@@ -299,6 +303,8 @@ void KMLCreator::finish(bool kmz) {
 
         QLOG_DEBUG() << "Done";
     }
+
+    return result;
 }
 
 void KMLCreator::writeWaypointsPlacemarkElement(QXmlStreamWriter &writer) {

--- a/src/output/kmlcreator.h
+++ b/src/output/kmlcreator.h
@@ -115,7 +115,7 @@ public:
 
     void processLine(QString &line);
 
-    void finish(bool kmz = false);
+    QString finish(bool kmz = false);
 
 private:
     Placemark *lastPlacemark();

--- a/src/ui/configuration/LogConsole.ui
+++ b/src/ui/configuration/LogConsole.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>821</width>
+    <width>864</width>
     <height>295</height>
    </rect>
   </property>
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QWidget" name="">
+  <widget class="QWidget" name="layoutWidget">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -54,6 +54,19 @@
     </item>
     <item>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item>
        <widget class="QPushButton" name="selectAllButton">
         <property name="text">

--- a/src/ui/configuration/TerminalConsole.cc
+++ b/src/ui/configuration/TerminalConsole.cc
@@ -40,8 +40,9 @@ This file is part of the APM_PLANNER project
 #include "Console.h"
 #include "configuration.h"
 #include "LogConsole.h"
+#include "MainWindow.h"
 
-
+#include <kmlcreator.h>
 #include <QSettings>
 #include <QStatusBar>
 #include <QMessageBox>
@@ -51,6 +52,7 @@ This file is part of the APM_PLANNER project
 #include <qserialportinfo.h>
 #include <qserialport.h>
 #include <QPointer>
+#include <QFileDialog>
 
 TerminalConsole::TerminalConsole(QWidget *parent) :
     QWidget(parent),
@@ -298,6 +300,7 @@ void TerminalConsole::initConnections()
 
     connect(ui->baudComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(setBaudRate(int)));
     connect(ui->linkComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(setLink(int)));
+    connect(ui->logToKmlButton, SIGNAL(released()), this, SLOT(logToKmlClicked()));
 
     // Serial Port Connections
     connect(m_serial, SIGNAL(error(QSerialPort::SerialPortError)), this,
@@ -309,6 +312,35 @@ void TerminalConsole::initConnections()
     connect(m_logConsole, SIGNAL(statusMessage(QString)), this, SLOT(logConsoleStatusMessage(QString)));
     connect(m_logConsole, SIGNAL(activityStart()), this, SLOT(logConsoleActivityStart()));
     connect(m_logConsole, SIGNAL(activityStop()), this, SLOT(logConsoleActivityStop()));
+}
+
+void TerminalConsole::logToKmlClicked() {
+    QString filename = QFileDialog::getOpenFileName(this, "Open Log File", MainWindow::instance()->getLogDirectory(), tr("Log Files (*.log)"));
+    if(filename.length() > 0) {
+        QFile file(filename);
+        if(file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            QString kmlFile(filename);
+            kmlFile.replace(".log", ".kml");
+            kml::KMLCreator kml;
+
+            kml.start(kmlFile);
+            QTextStream in(&file);
+            while(!in.atEnd()) {
+                QString line = in.readLine();
+                kml.processLine(line);
+            }
+
+            QString generated = kml.finish(true);
+            file.close();
+
+            QString msg = QString("Generated %1.").arg(generated);
+            QMessageBox::information(this, "Log to KML", msg);
+        }
+        else {
+            QString msg = QString("Unable to open %1.").arg(filename);
+            QMessageBox::warning(this, "Log to KML", msg, QMessageBox::Ok);
+        }
+    }
 }
 
 void TerminalConsole::logConsoleShown() {

--- a/src/ui/configuration/TerminalConsole.h
+++ b/src/ui/configuration/TerminalConsole.h
@@ -73,6 +73,7 @@ private slots:
     void logConsoleStatusMessage(QString);
     void logConsoleActivityStart();
     void logConsoleActivityStop();
+    void logToKmlClicked();
 
     void handleError(QSerialPort::SerialPortError error);
 

--- a/src/ui/configuration/TerminalConsole.ui
+++ b/src/ui/configuration/TerminalConsole.ui
@@ -139,6 +139,16 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="logToKmlButton">
+       <property name="toolTip">
+        <string>Pick a dataflash log file to generate a KML/KMZ file from</string>
+       </property>
+       <property name="text">
+        <string>Log to KML...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="logsButton">
        <property name="text">
         <string>Logs</string>


### PR DESCRIPTION
Add a "Log to KML" button in TerminalConsole to allow
generation of KML/KMZ file from a dataflash log already
on the file system.

When a UI for graphing logs and such is available, the
"Log to KML" button will (should?) be moved there.
