### PR TITLE
Fix for 89

### DIFF
--- a/src/ui/configuration/LogConsole.cc
+++ b/src/ui/configuration/LogConsole.cc
@@ -358,6 +358,7 @@ void LogConsole::pullSelectedClicked() {
             files.append(FileData(fn, logNumber));
         }
     }
+    
     disconnect(m_serial, SIGNAL(readyRead()), this, SLOT(readData()));
 
     if(files.size() > 0) {


### PR DESCRIPTION
Fix for logs 'pull selected' button to use correct log number instead of row number
