### PR TITLE
qmake install now works in Linux

### DIFF
--- a/qgroundcontrol.pri
+++ b/qgroundcontrol.pri
@@ -183,6 +183,11 @@ message(BASEDIR $$BASEDIR)
 # GNU/Linux
 linux-g++|linux-g++-64{
 
+        #VARIABLES
+        isEmpty(PREFIX) {
+                PREFIX = /usr
+        }
+
 	CONFIG -= console
 	DEFINES += __STDC_LIMIT_MACROS
 
@@ -255,18 +260,43 @@ linux-g++|linux-g++-64{
 	DESTDIR = $$TARGETDIR
 	QMAKE_POST_LINK += && cp -rf $$BASEDIR/files $$TARGETDIR
 	QMAKE_POST_LINK += && cp -rf $$BASEDIR/data $$TARGETDIR
-	QMAKE_POST_LINK += && mkdir -p $$TARGETDIR/files/images
-	QMAKE_POST_LINK += && cp -rf $$BASEDIR/files/styles/Vera.ttf $$TARGETDIR/files/styles/Vera.ttf
-        QMAKE_POST_LINK += && mkdir -p $$TARGETDIR/qml
-        QMAKE_POST_LINK += && cp -rf $$BASEDIR/qml/*.qml $$TARGETDIR/qml
+        QMAKE_POST_LINK += && cp -rf $$BASEDIR/qml $$TARGETDIR
 
-        QMAKE_POST_LINK += && mkdir -p $$TARGETDIR/qml/components/
-        QMAKE_POST_LINK += && cp -rf $$BASEDIR/qml/components/*.qml $$TARGETDIR/qml/components
+        #Installer section
+        BINDIR = $$PREFIX/bin
+        DATADIR =$$PREFIX/share
 
-        QMAKE_POST_LINK += && mkdir -p $$TARGETDIR/qml/resources
-        QMAKE_POST_LINK += && mkdir -p $$TARGETDIR/qml/resources/apmplanner
-        QMAKE_POST_LINK += && mkdir -p $$TARGETDIR/qml/resources/apmplanner/toolbar
-        QMAKE_POST_LINK += && cp -rf $$BASEDIR/qml/resources/apmplanner/toolbar/*.png $$TARGETDIR/qml/resources/apmplanner/toolbar
+        DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
+
+        #MAKE INSTALL - copy files
+        INSTALLS += target datafiles linkFiles linkData linkQML desktopLink menuLink permFolders permFiles
+
+        target.path =$$BINDIR
+
+        datafiles.path = $$DATADIR/APMPlanner
+        datafiles.files += $$BASEDIR/files
+        datafiles.files += $$BASEDIR/data
+        datafiles.files += $$BASEDIR/qml
+
+        #fix up file permissions. Bit of a hack job
+        permFolders.path = $$DATADIR/APMPlanner
+        permFolders.commands += find $$DATADIR -type d -exec chmod 755 {} \;
+        permFiles.path = $$DATADIR/APMPlanner
+        permFiles.commands += find $$DATADIR -type f -exec chmod 644 {} \;
+
+        #create file/folder links
+        linkFiles.path = $$BINDIR
+        linkFiles.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner/files
+        linkData.path = $$BINDIR
+        linkData.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner/data
+        linkQML.path = $$BINDIR
+        linkQML.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner/qml
+
+        #create menu links
+        desktopLink.path = $$DATADIR/menu
+        desktopLink.files += $$BASEDIR/scripts/debian/apmplanner2
+        menuLink.path = $$DATADIR/applications
+        menuLink.files += $$BASEDIR/scripts/debian/apmplanner2.desktop
 
 	# osg/osgEarth dynamic casts might fail without this compiler option.
 	# see http://osgearth.org/wiki/FAQ for details.

--- a/scripts/LinuxBuildPackage.sh
+++ b/scripts/LinuxBuildPackage.sh
@@ -1,60 +1,30 @@
 #!/bin/bash
 
 #run inside the /Script dir
-cd ../../
+cd ../
+
+NOW=$(date +"%Y%m%d")
 
 #build APM Planner
-qmake-qt4 ./apm_planner/qgroundcontrol.pro
+qmake-qt4 PREFIX=~/Documents/APMPlanner-$NOW/usr qgroundcontrol.pro
 make --jobs=3
+make install
 
 #Create folder structure
-NOW=$(date +"%Y%m%d")
-mkdir apmplanner-$NOW
-mkdir ./apmplanner-$NOW/debian
-mkdir ./apmplanner-$NOW/usr
-mkdir ./apmplanner-$NOW/usr/bin
-mkdir -p ./apmplanner-$NOW/usr/share/apmplanner2
-mkdir -p ./apmplanner-$NOW/usr/share/doc/apmplanner2
-mkdir -p ./apmplanner-$NOW/usr/share/menu
-mkdir -p ./apmplanner-$NOW/usr/share/applications
-
-#copy files over
-cp -r -f ./release/apmplanner2 ./apmplanner-$NOW/usr/bin
-cp -r -f ./release/data ./apmplanner-$NOW/usr/share/apmplanner2/data
-cp -r -f ./release/files ./apmplanner-$NOW/usr/share/apmplanner2/files
-cp -r -f ./release/qml ./apmplanner-$NOW/usr/share/apmplanner2/qml
+mkdir ~/Documents/APMPlanner-$NOW/DEBIAN
+install -m 755 -d ~/Documents/APMPlanner-$NOW/usr/share/doc/APMPlanner
 
 #copy deb support files
-cp -r -f ./apm_planner/scripts/debian/control ./apmplanner-$NOW/debian/control
-cp -f ./apm_planner/license.txt ./apmplanner-$NOW/usr/share/doc/apmplanner2/copyright
-cp -f ./apm_planner/scripts/debian/changelog ./apmplanner-$NOW/usr/share/doc/apmplanner2/changelog
-cp -r -f ./apm_planner/scripts/debian/postinst ./apmplanner-$NOW/debian/postinst
-cp -r -f ./apm_planner/scripts/debian/postrm ./apmplanner-$NOW/debian/postrm
-cp -f ./apm_planner/scripts/debian/apmplanner2 ./apmplanner-$NOW/usr/share/menu/apmplanner2
-cp -f ./apm_planner/scripts/debian/apmplanner2.desktop ./apmplanner-$NOW/usr/share/applications/apmplanner2.desktop
-gzip -9 ./apmplanner-$NOW/usr/share/doc/apmplanner2/changelog
-
-#make symbolic links to folders
-cd ./apmplanner-$NOW/usr/bin
-ln -s -r ../share/apmplanner2/files
-ln -s -r ../share/apmplanner2/data
-ln -s -r ../share/apmplanner2/qml
-cd ../../../
-
-#strip symbols from the binary
-strip -s  ./apmplanner-$NOW/usr/bin/apmplanner2
-mv ./apmplanner-$NOW/debian ./apmplanner-$NOW/DEBIAN
-
-#fix up permissions
-find ./apmplanner-$NOW/usr -type d -exec chmod 755 {} \;
-find ./apmplanner-$NOW/usr -type f -exec chmod 644 {} \;
-chmod 755 ./apmplanner-$NOW/DEBIAN/postinst
-chmod 755 ./apmplanner-$NOW/DEBIAN/postrm
-chmod +x ./apmplanner-$NOW/usr/bin/apmplanner2
+cp -r -f ./scripts/debian/control ~/Documents/APMPlanner-$NOW/DEBIAN/control
+install -m 644 ./license.txt ~/Documents/APMPlanner-$NOW/usr/share/doc/APMPlanner/copyright
+install -m 644 ./scripts/debian/changelog ~/Documents/APMPlanner-$NOW/usr/share/doc/APMPlanner/changelog
+install -m 755 ./scripts/debian/postinst ~/Documents/APMPlanner-$NOW/DEBIAN/postinst
+install -m 755 ./scripts/debian/postrm ~/Documents/APMPlanner-$NOW/DEBIAN/postrm
+gzip -9 ~/Documents/APMPlanner-$NOW/usr/share/doc/APMPlanner/changelog
 
 #create the pacakge and check compliance (report.txt)
-fakeroot dpkg-deb -b ./apmplanner-$NOW
-lintian apmplanner-$NOW.deb > report.txt
+fakeroot dpkg-deb -b ~/Documents/APMPlanner-$NOW
+lintian ~/Documents/APMPlanner-$NOW.deb > ~/Documents/report.txt
 
 
 

--- a/scripts/LinuxBuildPackageReadme.txt
+++ b/scripts/LinuxBuildPackageReadme.txt
@@ -1,9 +1,9 @@
 ---Using the Linux Script---
 
 The LinuxBuildPackage.sh script will do the following things:
-1. Build a release of apm_planner in the directory above apm_planner
-2. Create a .deb debian package in the directory above apm_planner
-3. Run the lintian checker to check for any errors in the package. A report is output at report.txt
+1. Build a release of apm_planner in the ~/Documents directory
+2. Create a .deb debian package in the ~/Documents directory
+3. Run the lintian checker to check for any errors in the package. A report is output at ~/Documents/report.txt
 
 Using the debian package:
 Due to this package not being an "official" Ubuntu/Debian/etc package, the installation process is a little convoluted for the first install. This is due to any dependencies not being able to be automatically installed alongside APM Planner.

--- a/scripts/debian/apmplanner2.desktop
+++ b/scripts/debian/apmplanner2.desktop
@@ -1,12 +1,11 @@
 [Desktop Entry]
 Type=Application
 Version=20131106
-Name=APM Planner 2
+Name=APM Planner
 GenericName=apmplanner2
 Exec=apmplanner2
 Terminal=false
 Categories=Education;Robotics;
 Comment=A UAV Ground Station
-Name=apmplanner2
 Icon=/usr/share/apmplanner2/files/APMIcons/ap_rc.png
 


### PR DESCRIPTION
Running "qmake install" will build APM Planner and install it on the user's system. 

Using the PREFIX=/some_dir/usr in the command will tell qmake to install APM Planner in the specified directory (default is /usr).
