### PR TITLE
search PATH for avrdude on linux based systems

### DIFF
--- a/src/ui/configuration/ApmFirmwareConfig.cc
+++ b/src/ui/configuration/ApmFirmwareConfig.cc
@@ -684,6 +684,30 @@ void ApmFirmwareConfig::downloadFinished()
                                    << "-cstk500" << QString("-P/dev/cu.").append(m_settings.name)
                                    << QString("-Uflash:w:").append(filename).append(":i");
 #endif
+#ifdef Q_OS_LINUX
+
+        // Check for avrdude in the PATH
+        QFile avrdude;
+
+        QByteArray path_array = qgetenv("PATH");
+        QString path_string = QString::fromUtf8(path_array.constData(),path_array.length());
+        QStringList path_list = path_string.split(":");
+        for (QStringList::iterator it = path_list.begin();it != path_list.end(); ++it){
+            QString current = *it;
+            current.append("/avrdude");
+            if (avrdude.exists(current.toAscii())){
+                avrdudeExecutable = current;
+                break;
+            }
+            else {
+                avrdudeExecutable = "";
+            }
+        }
+
+        stringList = QStringList() << "-v" << "-pm2560"
+                                   << "-cstk500" << QString("-P/dev/").append(m_settings.name)
+                                   << QString("-Uflash:w:").append(filename).append(":i");
+#endif
 
     // Start the Flashing
 


### PR DESCRIPTION
As a variation on the fix for issue #96 I wrote a detector for avrdude based on the PATH variable.
This can work on any Linux (or Mac) system as long as de folder that contains avrdude is in the PATH variable.
On Windows systems this will not work out of the box sins Windows uses a semicolon in stead of a colon as a separator in the PATH variable but this could be detected.
I saw that the original issue was solved already, but I wanted to share this because it can be of use for people that have avrdude in a non standard location. I they put that location in PATH then this will work out of the box.
