### PR TITLE
Changed the way APMPlanner2 handles looking for support files to be more...

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -194,3 +194,41 @@ WindowsBuild {
 		}
 	}
 }
+
+LinuxBuild {
+        #Installer section
+        BINDIR = $$PREFIX/bin
+        DATADIR =$$PREFIX/share
+
+        DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
+
+        #MAKE INSTALL - copy files
+        INSTALLS += target datafiles linkFiles linkData linkQML desktopLink menuLink permFolders permFiles
+
+        target.path =$$BINDIR
+
+        datafiles.path = $$DATADIR/APMPlanner2
+        datafiles.files += $$BASEDIR/files
+        datafiles.files += $$BASEDIR/data
+        datafiles.files += $$BASEDIR/qml
+
+        #fix up file permissions. Bit of a hack job
+        permFolders.path = $$DATADIR/APMPlanner2
+        permFolders.commands += find $$DATADIR -type d -exec chmod 755 {} \;
+        permFiles.path = $$DATADIR/APMPlanner2
+        permFiles.commands += find $$DATADIR -type f -exec chmod 644 {} \;
+
+        #create file/folder links
+        linkFiles.path = $$BINDIR
+        linkFiles.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/files
+        linkData.path = $$BINDIR
+        linkData.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/data
+        linkQML.path = $$BINDIR
+        linkQML.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/qml
+
+        #create menu links
+        desktopLink.path = $$DATADIR/menu
+        desktopLink.files += $$BASEDIR/scripts/debian/apmplanner2
+        menuLink.path = $$DATADIR/applications
+        menuLink.files += $$BASEDIR/scripts/debian/apmplanner2.desktop
+}

--- a/src/GAudioOutput.cc
+++ b/src/GAudioOutput.cc
@@ -30,6 +30,7 @@ This file is part of the QGROUNDCONTROL project
  */
 
 #include "QsLog.h"
+#include "configuration.h"
 #include "GAudioOutput.h"
 #include "MG.h"
 
@@ -246,7 +247,7 @@ void GAudioOutput::notifyPositive()
     if (!muted)
     {
         // Use QFile to transform path for all OS
-        QFile f(QCoreApplication::applicationDirPath()+QString("/files/audio/double_notify.wav"));
+        QFile f(QGC::shareDirectory()+QString("/files/audio/double_notify.wav"));
         //m_media->setCurrentSource(Phonon::MediaSource(f.fileName().toStdString().c_str()));
         //m_media->play();
     }
@@ -257,7 +258,7 @@ void GAudioOutput::notifyNegative()
     if (!muted)
     {
         // Use QFile to transform path for all OS
-        QFile f(QCoreApplication::applicationDirPath()+QString("/files/audio/flat_notify.wav"));
+        QFile f(QGC::shareDirectory()+QString("/files/audio/flat_notify.wav"));
         //m_media->setCurrentSource(Phonon::MediaSource(f.fileName().toStdString().c_str()));
         //m_media->play();
     }
@@ -303,7 +304,7 @@ void GAudioOutput::beep()
     if (!muted)
     {
         // Use QFile to transform path for all OS
-        QFile f(QCoreApplication::applicationDirPath()+QString("/files/audio/alert.wav"));
+        QFile f(QGC::shareDirectory()+QString("/files/audio/alert.wav"));
         QLOG_INFO() << "FILE:" << f.fileName();
         //m_media->setCurrentSource(Phonon::MediaSource(f.fileName().toStdString().c_str()));
         //m_media->play();

--- a/src/MG.h
+++ b/src/MG.h
@@ -342,63 +342,6 @@ public:
 
 };
 
-class DIR
-{
-
-public:
-    /**
-     * @brief Get the current support file directory.
-     *
-     * The support files are files like icons or fonts and are typically found in the
-     * same directory as the main executable.
-     *
-     * @return The absolute path of the directory
-     **/
-    static QString getSupportFilesDirectory() {
-
-        // Checks if the software is executed in the development environment
-        QString path = QDir::current().absolutePath();
-        QDir currentDir = QDir::current();
-
-        if (QDir::current().dirName().toLower() == "debug") {
-            // Debug folder of development environment
-            path.append("/..");
-        } else if (QDir::current().dirName().toLower() == "release") {
-            // Release folder of development environment
-            path.append("/..");
-        } else if (QDir::current().dirName().toLower() == "bin") {
-            // Release folder of development environment
-            path.append("/..");
-        } else if (QDir::current().dirName().toLower() == "macos") {
-            // Mac application bundle in development environment
-            path.append("/../../../../..");
-        }
-
-        // Check if we are still in a development folder
-        if(currentDir.cdUp()) {
-            if(currentDir.dirName().toLower() == "build") {
-                path.append("/..");
-            }
-        }
-        //TODO The Mac application bundle in distribution is not yet included here
-        //QLOG_DEBUG() << "MG::supportfilesdirectory" << path;
-        return path;
-    }
-
-    /**
-     * @brief Get the current icon directory.
-     *
-     * The icon directory is typically a subdirectory of the main directory,
-     * but depends on the platform. For example in OS X it is part of the bundle.
-     *
-     * @return The absolute path of the icon directory
-     **/
-    static QString getIconDirectory() {
-        return MG::DIR::getSupportFilesDirectory() + "/files/images/";
-    }
-
-};
-
 }
 
 #endif // _MG_H_

--- a/src/comm/ParameterList.cc
+++ b/src/comm/ParameterList.cc
@@ -37,9 +37,7 @@ ParameterList::ParameterList()
      reqdServoParams(new QStringList())
 {
 
-    QDir settingsDir = QDir(qApp->applicationDirPath());
-    if (settingsDir.dirName() == "bin")
-        settingsDir.cdUp();
+    QDir settingsDir = QDir(QGC::shareDirectory());
     settingsDir.cd("data");
 
     // Enforce a list of parameters which are necessary for flight

--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -395,7 +395,7 @@ bool QGCFlightGearLink::connectSimulation()
     terraSyncScenery = QDir::homePath() + "/.terrasync/Scenery"; //according to http://wiki.flightgear.org/TerraSync a separate directory is used
 #endif
 
-    fgAircraft = QApplication::applicationDirPath() + "/files/flightgear/Aircraft";
+    fgAircraft = QGC::shareDirectory() + "/files/flightgear/Aircraft";
 
     // Sanity checks
     bool sane = true;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -4,6 +4,7 @@
 #include "globalobject.h"
 #include <QString>
 #include <QDateTime>
+#include <QDir>
 
 /** @brief Polling interval in ms */
 #define SERIAL_POLL_INTERVAL 100
@@ -79,6 +80,33 @@ const int APPLICATIONVERSION = 200; // 2.0.0
 
     static void setParameterDirectory(const QString& dir){
         GlobalObject::sharedInstance()->setParameterDirectory(dir);
+    }
+
+
+    //Returns the absolute parth to the files, data, qml support directories
+    //It could be in 1 of 2 places under Linux
+    static QString shareDirectory(){
+#ifdef Q_OS_WIN || Q_OS_MAC
+        QDir settingsDir = QDir(QDir::currentPath());
+        return  settingsDir.absolutePath();
+#else
+        QDir settingsDir = QDir(QDir::currentPath());
+        if(settingsDir.exists("data") && settingsDir.exists("qml"))
+        {
+            return  settingsDir.absolutePath();
+        }
+        settingsDir.cdUp();
+        settingsDir.cd("./share/APMPlanner2");
+        if(settingsDir.exists("data") && settingsDir.exists("qml"))
+        {
+            QString tmp = settingsDir.absolutePath();
+            return  settingsDir.absolutePath();
+        }
+
+        //else
+        return QDir(QDir::currentPath()).absolutePath();
+
+#endif
     }
 
 }

--- a/src/input/Freenect.cc
+++ b/src/input/Freenect.cc
@@ -284,7 +284,7 @@ Freenect::FreenectThread::run(void)
 void
 Freenect::readConfigFile(void)
 {
-    QSettings settings("src/data/kinect.cal", QSettings::IniFormat, 0);
+    QSettings settings(QGC::shareDirectory() + "/data/kinect.cal", QSettings::IniFormat, 0);
 
     rgbCameraParameters.cx = settings.value("rgb/principal_point/x").toDouble();
     rgbCameraParameters.cy = settings.value("rgb/principal_point/y").toDouble();

--- a/src/ui/ApmToolBar.cc
+++ b/src/ui/ApmToolBar.cc
@@ -45,9 +45,9 @@ APMToolBar::APMToolBar(QWidget *parent):
 
     QDir qmlBaseDir = QDir(qApp->applicationDirPath());
     QLOG_DEBUG() << "qmlBaseDir" << qmlBaseDir;
-    QUrl url = QUrl::fromLocalFile(qmlBaseDir.absolutePath() + "/qml/ApmToolBar.qml");
+    QUrl url = QUrl::fromLocalFile(QGC::shareDirectory() + "/qml/ApmToolBar.qml");
     QLOG_DEBUG() << url;
-    if (!QFile::exists(qmlBaseDir.absolutePath() + "/qml/ApmToolBar.qml"))
+    if (!QFile::exists(QGC::shareDirectory() + "/qml/ApmToolBar.qml"))
     {
          QMessageBox::information(0,"Error","ApmToolBar.qml not found. Please reinstall the application and try again");
         exit(-1);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -1160,8 +1160,8 @@ void MainWindow::loadCustomWidget(const QString& fileName, bool singleinstance)
 
 void MainWindow::loadCustomWidgetsFromDefaults(const QString& systemType, const QString& autopilotType)
 {
-    QString defaultsDir = QGC::appDataDirectory() + "/files/" + autopilotType.toLower() + "/widgets/";
-    QString platformDir = QGC::appDataDirectory() + "/files/" + autopilotType.toLower() + "/" + systemType.toLower() + "/widgets/";
+    QString defaultsDir = QGC::shareDirectory() + "/files/" + autopilotType.toLower() + "/widgets/";
+    QString platformDir = QGC::shareDirectory() + "/files/" + autopilotType.toLower() + "/" + systemType.toLower() + "/widgets/";
 
     QDir widgets(defaultsDir);
     QStringList files = widgets.entryList();
@@ -1397,7 +1397,7 @@ void MainWindow::reloadStylesheet()
     if (styleSheet->open(QIODevice::ReadOnly | QIODevice::Text))
     {
         QString style = QString(styleSheet->readAll());
-        style.replace("ICONDIR", QCoreApplication::applicationDirPath()+ "files/styles/");
+        style.replace("ICONDIR", QGC::shareDirectory() + "/files/styles/");
         qApp->setStyleSheet(style);
     }
     else
@@ -1944,7 +1944,7 @@ void MainWindow::UASCreated(UASInterface* uas)
         if (!detectionDockWidget)
         {
             detectionDockWidget = new QDockWidget(tr("Object Recognition"), this);
-            detectionDockWidget->setWidget( new ObjectDetectionView("files/images/patterns", this) );
+            detectionDockWidget->setWidget( new ObjectDetectionView("/files/images/patterns", this) );
             detectionDockWidget->setObjectName("OBJECT_DETECTION_DOCK_WIDGET");
             //addTool(detectionDockWidget, tr("Object Recognition"), Qt::RightDockWidgetArea);
         }

--- a/src/ui/ObjectDetectionView.h
+++ b/src/ui/ObjectDetectionView.h
@@ -65,7 +65,7 @@ class ObjectDetectionView : public QWidget
     };
 
 public:
-    explicit ObjectDetectionView(QString folder="files/images/patterns", QWidget *parent = 0);
+    explicit ObjectDetectionView(QString folder="/files/images/patterns", QWidget *parent = 0);
     virtual ~ObjectDetectionView();
 
     /** @brief Resize widget contents */

--- a/src/ui/QGCVehicleConfig.cc
+++ b/src/ui/QGCVehicleConfig.cc
@@ -245,7 +245,7 @@ void QGCVehicleConfig::stopCalibrationRC()
 void QGCVehicleConfig::loadQgcConfig(bool primary)
 {
     Q_UNUSED(primary);
-    QDir autopilotdir(qApp->applicationDirPath() + "/files/" + mav->getAutopilotTypeName().toLower());
+    QDir autopilotdir(QGC::shareDirectory() + "/files/" + mav->getAutopilotTypeName().toLower());
     QDir generaldir = QDir(autopilotdir.absolutePath() + "/general/widgets");
     QDir vehicledir = QDir(autopilotdir.absolutePath() + "/" + mav->getSystemTypeName().toLower() + "/widgets");
     if (!autopilotdir.exists("general"))
@@ -468,7 +468,7 @@ void QGCVehicleConfig::loadConfig()
 {
     QGCToolWidget* tool;
 
-    QDir autopilotdir(qApp->applicationDirPath() + "/files/" + mav->getAutopilotTypeName().toLower());
+    QDir autopilotdir(QGC::shareDirectory() + "/files/" + mav->getAutopilotTypeName().toLower());
     QDir generaldir = QDir(autopilotdir.absolutePath() + "/general/widgets");
     QDir vehicledir = QDir(autopilotdir.absolutePath() + "/" + mav->getSystemTypeName().toLower() + "/widgets");
     if (!autopilotdir.exists("general"))

--- a/src/ui/XbeeConfigurationWindow.h
+++ b/src/ui/XbeeConfigurationWindow.h
@@ -7,9 +7,9 @@
 #include <QTimer>
 #include <QShowEvent>
 #include <QHideEvent>
-#include<QtGui\qcombobox.h>
-#include<QtGui\qlabel.h>
-#include<QtGui\qlayout.h>
+#include<qcombobox.h>
+#include<qlabel.h>
+#include<qlayout.h>
 #include <LinkInterface.h>
 #include"XbeeLinkInterface.h"
 #include "../comm/HexSpinBox.h"

--- a/src/ui/configuration/ApmSoftwareConfig.cc
+++ b/src/ui/configuration/ApmSoftwareConfig.cc
@@ -244,7 +244,7 @@ void ApmSoftwareConfig::activeUASSet(UASInterface *uas)
     m_apmPdefFilename = QDir(appDataDir + "/apmplanner2").filePath("apm.pdef.xml");
     if (!QFile::exists(m_apmPdefFilename))
     {
-        QDir autopilotdir(qApp->applicationDirPath() + "/files/" + uas->getAutopilotTypeName().toLower());
+        QDir autopilotdir(QGC::shareDirectory() + "/files/" + uas->getAutopilotTypeName().toLower());
         m_apmPdefFilename = autopilotdir.absolutePath() + "/arduplane.pdef.xml";
     }
 

--- a/src/ui/map3D/Q3DWidget.cc
+++ b/src/ui/map3D/Q3DWidget.cc
@@ -56,7 +56,7 @@ Q3DWidget::Q3DWidget(QWidget* parent)
     fontImpl = new osgQt::QFontImplementation(QFont(":/general/vera.ttf"));
 #else
     osg::ref_ptr<osgText::Font::FontImplementation> fontImpl;
-    fontImpl = 0;//new osgText::Font::Font("files/styles/Vera.ttf");
+    fontImpl = 0;//new osgText::Font::Font("/files/styles/Vera.ttf");
 #endif
     mFont = new osgText::Font(fontImpl);
 


### PR DESCRIPTION
Program can now handle the support files being in ../share/APMPlanner2 on Linux. A number of changes were required throughout the program to point to a single routine in configuration.h QGC::shareDirectory(), whose purpose is to return the location of the support files.

This way Linux won't need hacky shortcuts in the /bin directory, making the installation process easier/safer.

It seems that the merge from qgroundcontrol last week "Cleaned up build files (inline with QGC changes 34c2c3d980)" inadvertently removed some of my build changes from two weeks ago, by unincluding qgroundcontrol.pri in the build process. I've put those changes in QGCSetup.pri instead.
