### PR TITLE
Linux: Forced usage of libudev for serial ports. Also minor build fixes

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -203,7 +203,7 @@ LinuxBuild {
         DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
 
         #MAKE INSTALL - copy files
-        INSTALLS += target datafiles linkFiles linkData linkQML desktopLink menuLink permFolders permFiles
+        INSTALLS += target datafiles desktopLink menuLink permFolders permFiles
 
         target.path =$$BINDIR
 
@@ -217,14 +217,6 @@ LinuxBuild {
         permFolders.commands += find $$DATADIR -type d -exec chmod 755 {} ;
         permFiles.path = $$DATADIR/APMPlanner2
         permFiles.commands += find $$DATADIR -type f -exec chmod 644 {} ;
-
-        #create file/folder links
-        linkFiles.path = $$BINDIR
-        linkFiles.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/files
-        linkData.path = $$BINDIR
-        linkData.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/data
-        linkQML.path = $$BINDIR
-        linkQML.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/qml
 
         #create menu links
         desktopLink.path = $$DATADIR/menu

--- a/libs/serialport/apmserial.pri
+++ b/libs/serialport/apmserial.pri
@@ -3,9 +3,16 @@ INCLUDEPATH += $$PWD
 unix {
     CONFIG += link_pkgconfig
 
-    packagesExist(libudev) {
-        DEFINES += HAVE_LIBUDEV
-        PKGCONFIG += libudev
+    macx {
+        packagesExist(libudev) {
+            DEFINES += HAVE_LIBUDEV
+            PKGCONFIG += libudev
+        }
+    }
+
+    linux* {
+    DEFINES += HAVE_LIBUDEV
+    PKGCONFIG += libudev
     }
 }
 
@@ -49,7 +56,7 @@ unix:!symbian {
 
         LIBS += -framework IOKit -framework CoreFoundation
     } else {
-        linux*:contains( DEFINES, HAVE_LIBUDEV ) {
+        linux*{
             LIBS += -ludev
         }
     }

--- a/libs/serialport/qserialportinfo_unix.cpp
+++ b/libs/serialport/qserialportinfo_unix.cpp
@@ -49,14 +49,11 @@
 
 #ifndef Q_OS_MAC
 
-#if defined (Q_OS_LINUX) && defined (HAVE_LIBUDEV)
+#if defined (Q_OS_LINUX)
 extern "C"
 {
 #include <libudev.h>
 }
-#else
-#include <QtCore/qdir.h>
-#include <QtCore/qstringlist.h>
 #endif
 
 #endif // Q_OS_MAC
@@ -65,7 +62,7 @@ QT_BEGIN_NAMESPACE
 
 #ifndef Q_OS_MAC
 
-#if !(defined (Q_OS_LINUX) && defined (HAVE_LIBUDEV))
+#if !(defined (Q_OS_LINUX))
 
 static inline const QStringList& filtersOfDevices()
 {
@@ -95,7 +92,7 @@ QList<QSerialPortInfo> QSerialPortInfo::availablePorts()
 {
     QList<QSerialPortInfo> serialPortInfoList;
 
-#if defined (Q_OS_LINUX) && defined (HAVE_LIBUDEV)
+#if defined (Q_OS_LINUX)
 
     // White list for devices without a parent
     static const QString rfcommDeviceName(QLatin1String("rfcomm"));

--- a/qgroundcontrol.pri
+++ b/qgroundcontrol.pri
@@ -269,7 +269,7 @@ linux-g++|linux-g++-64{
         DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
 
         #MAKE INSTALL - copy files
-        INSTALLS += target datafiles linkFiles linkData linkQML desktopLink menuLink permFolders permFiles
+        INSTALLS += target datafiles desktopLink menuLink permFolders permFiles
 
         target.path =$$BINDIR
 
@@ -283,14 +283,6 @@ linux-g++|linux-g++-64{
         permFolders.commands += find $$DATADIR -type d -exec chmod 755 {} \;
         permFiles.path = $$DATADIR/APMPlanner2
         permFiles.commands += find $$DATADIR -type f -exec chmod 644 {} \;
-
-        #create file/folder links
-        linkFiles.path = $$BINDIR
-        linkFiles.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/files
-        linkData.path = $$BINDIR
-        linkData.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/data
-        linkQML.path = $$BINDIR
-        linkQML.commands += ln -s -f -t $$BINDIR $$DATADIR/APMPlanner2/qml
 
         #create menu links
         desktopLink.path = $$DATADIR/menu

--- a/scripts/LinuxBuildPackage.sh
+++ b/scripts/LinuxBuildPackage.sh
@@ -4,27 +4,31 @@
 cd ../
 
 NOW=$(date +"%Y%m%d")
+GIT_VERSION=$(git describe --abbrev=0)
 
 #build APM Planner
-qmake-qt4 PREFIX=~/Documents/APMPlanner2-$NOW/usr qgroundcontrol.pro
+qmake-qt4 PREFIX=~/Documents/APMPlanner2_$GIT_VERSION/usr qgroundcontrol.pro
 make --jobs=3
 make install
 
 #Create folder structure
-mkdir ~/Documents/APMPlanner2-$NOW/DEBIAN
-install -m 755 -d ~/Documents/APMPlanner2-$NOW/usr/share/doc/APMPlanner2
+mkdir ~/Documents/APMPlanner2_$GIT_VERSION/DEBIAN
+install -m 755 -d ~/Documents/APMPlanner2_$GIT_VERSION/usr/share/doc/APMPlanner2
 
 #copy deb support files
-cp -r -f ./scripts/debian/control ~/Documents/APMPlanner2-$NOW/DEBIAN/control
-install -m 644 ./license.txt ~/Documents/APMPlanner2-$NOW/usr/share/doc/APMPlanner2/copyright
-install -m 644 ./scripts/debian/changelog ~/Documents/APMPlanner2-$NOW/usr/share/doc/APMPlanner2/changelog
-install -m 755 ./scripts/debian/postinst ~/Documents/APMPlanner2-$NOW/DEBIAN/postinst
-install -m 755 ./scripts/debian/postrm ~/Documents/APMPlanner2-$NOW/DEBIAN/postrm
-gzip -9 ~/Documents/APMPlanner2-$NOW/usr/share/doc/APMPlanner2/changelog
+cp -r -f ./scripts/debian/control ~/Documents/APMPlanner2_$GIT_VERSION/DEBIAN/control
+install -m 644 ./license.txt ~/Documents/APMPlanner2_$GIT_VERSION/usr/share/doc/APMPlanner2/copyright
+install -m 644 ./scripts/debian/changelog ~/Documents/APMPlanner2_$GIT_VERSION/usr/share/doc/APMPlanner2/changelog
+install -m 755 ./scripts/debian/postinst ~/Documents/APMPlanner2_$GIT_VERSION/DEBIAN/postinst
+install -m 755 ./scripts/debian/postrm ~/Documents/APMPlanner2_$GIT_VERSION/DEBIAN/postrm
+gzip -9 ~/Documents/APMPlanner2_$GIT_VERSION/usr/share/doc/APMPlanner2/changelog
+
+#add version number to control file
+sed -i "s/VERSION/$GIT_VERSION/g" ~/Documents/APMPlanner2_$GIT_VERSION/DEBIAN/control
 
 #create the pacakge and check compliance (report.txt)
-fakeroot dpkg-deb -b ~/Documents/APMPlanner2-$NOW
-lintian ~/Documents/APMPlanner2-$NOW.deb > ~/Documents/report.txt
+fakeroot dpkg-deb -b ~/Documents/APMPlanner2_$GIT_VERSION
+lintian ~/Documents/APMPlanner2_$GIT_VERSION.deb > ~/Documents/report.txt
 
 
 

--- a/scripts/debian/control
+++ b/scripts/debian/control
@@ -1,6 +1,6 @@
 Package: apmplanner2
 Source: apmplanner
-Version: 20131103
+Version: VERSION
 Maintainer: APM Planner Developers <stephen_dade@hotmail.com>
 Installed-Size: 92263
 Section: science


### PR DESCRIPTION
Forced usage of libudev in APMSerial, as it's the only reliable port detection method. Should fix #168

Minor cleanup of build files, including proper version labeling in deb file creation.
