### PR TITLE
Add in a missing stdint.h include

### DIFF
--- a/src/ui/QGCTCPLinkConfiguration.cc
+++ b/src/ui/QGCTCPLinkConfiguration.cc
@@ -2,6 +2,7 @@
 
 #include "QGCTCPLinkConfiguration.h"
 #include "ui_QGCTCPLinkConfiguration.h"
+#include <stdint.h>
 
 QGCTCPLinkConfiguration::QGCTCPLinkConfiguration(TCPLink* link, QWidget *parent) :
     QWidget(parent),


### PR DESCRIPTION
Causes build to fail complaining about uint16_t without it.
