### PR TITLE
ArchLinux now builds

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -128,6 +128,7 @@ MacBuild {
 }
 
 LinuxBuild {
+    QT += script
     DEFINES += __STDC_LIMIT_MACROS
 
     DEFINES += GIT_COMMIT=$$system(git describe --dirty=-DEV --always)
@@ -135,6 +136,7 @@ LinuxBuild {
 
     LIBS += -lz
     LIBS += -lssl -lcrypto
+    LIBS += -lasound -lsndfile
 }
 
 WindowsBuild {


### PR DESCRIPTION
Adding the qtscript to QT and the -lasound and -lsndfile to LIBS, Apm Planner builds in ArchLinux x64.
