### PR TITLE
Linux: Added extra search paths for support files

### DIFF
--- a/src/globalobject.cc
+++ b/src/globalobject.cc
@@ -182,7 +182,18 @@ QString GlobalObject::shareDirectory()
         QString tmp = settingsDir.absolutePath();
         return  settingsDir.absolutePath();
     }
-
+    settingsDir = QDir("/usr/share/APMPlanner2");
+    if(settingsDir.exists("data") && settingsDir.exists("qml"))
+    {
+        QString tmp = settingsDir.absolutePath();
+        return  settingsDir.absolutePath();
+    }
+    settingsDir = QDir("/usr/local/share/APMPlanner2");
+    if(settingsDir.exists("data") && settingsDir.exists("qml"))
+    {
+        QString tmp = settingsDir.absolutePath();
+        return  settingsDir.absolutePath();
+    }
     //else
     return QDir(QDir::currentPath()).absolutePath();
 

--- a/src/ui/ApmToolBar.cc
+++ b/src/ui/ApmToolBar.cc
@@ -47,7 +47,7 @@ APMToolBar::APMToolBar(QWidget *parent):
     QLOG_DEBUG() << url;
     if (!QFile::exists(QGC::shareDirectory() + "/qml/ApmToolBar.qml"))
     {
-         QMessageBox::information(0,"Error","ApmToolBar.qml not found. Please reinstall the application and try again");
+        QMessageBox::information(0,"Error", "" + QGC::shareDirectory() + "/qml/ApmToolBar.qml" + " not found. Please reinstall the application and try again");
         exit(-1);
     }
     setSource(url);


### PR DESCRIPTION
On some Linux systems, the searching for the support folders (data, qml, etc) fails. This patch expands the search to typical locations that APMPlanner might be installed to.
