### PR TITLE
Fixed correct APM detection

### DIFF
--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -178,7 +178,7 @@ void SerialLink::run()
             break;
         }
     }
-    if (description.contains("mega") && description.contains("2560"))
+    if (description.contains("Mega") && description.contains("2560"))
     {
         QLOG_DEBUG() << "Connected to an APM, with description:" << description;
     }


### PR DESCRIPTION
Correct USB descriptor of Arduino Mega (And all my APM's) is:
  iManufacturer           1 Arduino (www.arduino.cc)
  iProduct                2 Arduino Mega 2560

with the M in uppercase, so on my linux system (ArchLinux), I got "Connected to a NON-APM or 3DR Radio with description:". This fix corrects that.
