### PR TITLE
Linux: Fixed typo in menu shortcut location

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -220,7 +220,7 @@ LinuxBuild {
 
         #create menu links
         desktopLink.path = $$DATADIR/menu
-        desktopLink.files += $$BASEDIR/scripts/debian/apmplanner2
+        desktopLink.files += $$BASEDIR/debian/apmplanner2
         menuLink.path = $$DATADIR/applications
-        menuLink.files += $$BASEDIR/scripts/debian/apmplanner2.desktop
+        menuLink.files += $$BASEDIR/debian/apmplanner2.desktop
 }


### PR DESCRIPTION
The will allow a shortcut to APM Planner to appear in the system menu (or equivalent).
Fix for #269
