### PR TITLE
Graph: data source can now be toggle with keyboard too.

### DIFF
--- a/src/ui/dataselectionscreen.cpp
+++ b/src/ui/dataselectionscreen.cpp
@@ -5,7 +5,7 @@
 DataSelectionScreen::DataSelectionScreen(QWidget *parent) : QWidget(parent)
 {
 	ui.setupUi(this);
-    connect(ui.treeWidget,SIGNAL(itemClicked(QTreeWidgetItem*,int)),this,SLOT(treeDoubleClicked(QTreeWidgetItem*,int)));
+    connect(ui.treeWidget, SIGNAL(itemChanged(QTreeWidgetItem*,int)), this, SLOT(onItemChanged(QTreeWidgetItem*,int)));
     connect(ui.clearPushButton,SIGNAL(clicked()),this,SLOT(clearSelectionButtonClicked()));
 }
 
@@ -22,9 +22,7 @@ void DataSelectionScreen::clearSelectionButtonClicked()
             if (items[i]->checkState(0) == Qt::Checked)
             {
                 items[i]->setCheckState(0,Qt::Unchecked);
-                QString name = items[i]->parent()->text(0) + "." + items[i]->text(0);
-                m_enabledList.removeOne(name);
-                emit itemDisabled(name);
+                // ^^ this will trigger the disabling of the graph automatically
             }
         }
     }
@@ -110,7 +108,7 @@ void DataSelectionScreen::addItem(QString name)
 
     }
 }
-void DataSelectionScreen::treeDoubleClicked(QTreeWidgetItem* item,int column)
+void DataSelectionScreen::onItemChanged(QTreeWidgetItem* item,int column)
 {
     if (!item->parent())
     {

--- a/src/ui/dataselectionscreen.h
+++ b/src/ui/dataselectionscreen.h
@@ -19,7 +19,7 @@ signals:
 	void itemEnabled(QString name);
 	void itemDisabled(QString name);
 private slots:
-    void treeDoubleClicked(QTreeWidgetItem* item,int column);
+    void onItemChanged(QTreeWidgetItem* item,int column);
     void clearSelectionButtonClicked();
 private:
     QMap<QString,QString> m_nameToSysId;


### PR DESCRIPTION
Previously, the data toggle was hooked to the mouse-click handler. Now I hooked it to the itemChanged() handler, which gets invoked by pressing space.

This should fix #222.
