### PR TITLE
Config: filtering standard and advanced parameters

### DIFF
--- a/src/ui/configuration/AdvancedParamConfig.cc
+++ b/src/ui/configuration/AdvancedParamConfig.cc
@@ -28,6 +28,7 @@ AdvancedParamConfig::AdvancedParamConfig(QWidget *parent) : AP2ConfigWidget(pare
     ui.setupUi(this);
     initConnections();
 
+    connect(ui.searchFilter, SIGNAL(textChanged(QString)), this, SLOT(onSearchFilterChanged(const QString &)));
 }
 
 AdvancedParamConfig::~AdvancedParamConfig()
@@ -68,6 +69,11 @@ void AdvancedParamConfig::addCombo(QString title, QString description, QString p
     }
 }
 
+void AdvancedParamConfig::allParamsAdded(void)
+{
+    ui.verticalLayout->addStretch();
+}
+
 void AdvancedParamConfig::parameterChanged(int uas, int component, QString parameterName, QVariant value)
 {
     if (m_paramToWidgetMap.contains(parameterName))
@@ -103,4 +109,36 @@ void AdvancedParamConfig::intValueChanged(QString param, int value)
         this->showNullMAVErrorMessageBox();
     }
     m_uas->getParamManager()->setParameter(1,param,value);
+}
+
+void AdvancedParamConfig::onSearchFilterChanged(const QString &searchFilterText)
+{
+    if (searchFilterText.isEmpty())
+    {
+        for (int i = 0; i < ui.verticalLayout->count(); ++i)
+        {
+            QLayoutItem *item = ui.verticalLayout->itemAt(i);
+            if (item && item->widget())
+            {
+                item->widget()->setVisible(true);
+            }
+        }
+    }
+    else
+    {
+        QStringList filterList = searchFilterText.toLower().split(' ', QString::SkipEmptyParts);
+        for (int i = 0; i < ui.verticalLayout->count(); ++i)
+        {
+            ParamWidget *pw = qobject_cast<ParamWidget *>(ui.verticalLayout->itemAt(i)->widget());
+            if (pw)
+            {
+                bool shouldShow = true;
+                foreach (const QString &filterTerm, filterList)
+                {
+                    shouldShow = shouldShow && pw->matchesSearchFilter(filterTerm);
+                }
+                pw->setVisible(shouldShow);
+            }
+        }
+    }
 }

--- a/src/ui/configuration/AdvancedParamConfig.h
+++ b/src/ui/configuration/AdvancedParamConfig.h
@@ -44,11 +44,13 @@ public:
     ~AdvancedParamConfig();
     void addRange(QString title,QString description,QString param,double min,double max,double increment);
     void addCombo(QString title,QString description,QString param,QList<QPair<int,QString> > valuelist);
+    void allParamsAdded(void);
 
 private slots:
     void parameterChanged(int uas, int component, QString parameterName, QVariant value);
     void doubleValueChanged(QString param,double value);
     void intValueChanged(QString param,int value);
+    void onSearchFilterChanged(const QString &searchFilterText);
 
 private:
     QMap<QString,ParamWidget*> m_paramToWidgetMap;

--- a/src/ui/configuration/AdvancedParamConfig.ui
+++ b/src/ui/configuration/AdvancedParamConfig.ui
@@ -15,10 +15,51 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;h2&gt;Advanced Params&lt;/h2&gt;</string>
-     </property>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>&lt;h2&gt;Advanced Params&lt;/h2&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="searchFilter">
+        <property name="toolTip">
+         <string>Type words separated by spaces. Only parameters which match all search terms will be displayed.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Filter</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -31,8 +72,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>705</width>
-        <height>585</height>
+        <width>699</width>
+        <height>572</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/ui/configuration/ApmSoftwareConfig.cc
+++ b/src/ui/configuration/ApmSoftwareConfig.cc
@@ -485,6 +485,8 @@ void ApmSoftwareConfig::populateTimerTick()
         populateTimer->stop();
         populateTimer->deleteLater();
         populateTimer = 0;
+        m_advancedParamConfig->allParamsAdded();
+        m_standardParamConfig->allParamsAdded();
         return;
     }
     if (m_paramConfigList.at(0).isRange)

--- a/src/ui/configuration/ParamWidget.cc
+++ b/src/ui/configuration/ParamWidget.cc
@@ -38,6 +38,7 @@ ParamWidget::ParamWidget(QString param,QWidget *parent) : QWidget(parent)
     }
 
     m_param = param;
+    m_searchableText = param;
 
     connect(ui.doubleSpinBox,SIGNAL(editingFinished()),this,SLOT(doubleSpinEditFinished()));
     connect(ui.doubleSpinBox,SIGNAL(returnPressed()),this,SLOT(doubleSpinEditFinished()));
@@ -169,6 +170,8 @@ void ParamWidget::setupInt(QString title,QString description,int value,int min,i
     ui.intSpinBox->setMaximum(m_max);
     ui.minLabel->setText(QString::number(m_min));
     ui.maxLabel->setText(QString::number(m_max));
+
+    m_searchableText.append(QString(" %1 %2").arg(title).arg(description));
 }
 
 void ParamWidget::setupDouble(QString title,QString description,double value,double min,double max,double increment)
@@ -223,6 +226,8 @@ void ParamWidget::setupDouble(QString title,QString description,double value,dou
     ui.doubleSpinBox->setSingleStep(increment);
     ui.doubleSpinBox->setMinimum(m_min);
     ui.doubleSpinBox->setMaximum(m_max);
+
+    m_searchableText.append(QString(" %1 %2").arg(title).arg(description));
 }
 
 void ParamWidget::setupCombo(QString title,QString description,QList<QPair<int,QString> > list)
@@ -244,6 +249,13 @@ void ParamWidget::setupCombo(QString title,QString description,QList<QPair<int,Q
         ui.valueComboBox->addItem(m_valueList[i].second);
     }
     connect(ui.valueComboBox,SIGNAL(currentIndexChanged(int)),this,SLOT(comboIndexChanged(int)));
+
+    m_searchableText.append(QString(" %1 %2").arg(title).arg(description));
+    for (int i = 0; i < m_valueList.size(); ++i)
+    {
+        // also add the combo values to be filtered against
+        m_searchableText.append(QString(" %1").arg(m_valueList[i].second));
+    }
 }
 
 void ParamWidget::setValue(double value)
@@ -304,4 +316,9 @@ void ParamWidget::setValue(double value)
             }
         }
     }
+}
+
+bool ParamWidget::matchesSearchFilter(const QString &searchFilter)
+{
+    return m_searchableText.toLower().contains(searchFilter);
 }

--- a/src/ui/configuration/ParamWidget.h
+++ b/src/ui/configuration/ParamWidget.h
@@ -37,6 +37,7 @@ public:
     void setupDouble(QString title,QString description,double value,double min,double max,double increment);
     void setupCombo(QString title,QString description,QList<QPair<int,QString> > list);
     void setValue(double value);
+    bool matchesSearchFilter(const QString &searchFilter);
 signals:
     void doubleValueChanged(QString param,double value);
     void intValueChanged(QString param,int value);
@@ -52,6 +53,7 @@ private:
     QPalette intSpinBoxPalette;
     bool m_valueChanged;
     QString m_param;
+    QString m_searchableText;
     enum VIEWTYPE
     {
         INT,

--- a/src/ui/configuration/StandardParamConfig.cc
+++ b/src/ui/configuration/StandardParamConfig.cc
@@ -29,10 +29,16 @@ StandardParamConfig::StandardParamConfig(QWidget *parent) : AP2ConfigWidget(pare
 {
     ui.setupUi(this);
     initConnections();
+    connect(ui.searchFilter, SIGNAL(textChanged(QString)), this, SLOT(onSearchFilterChanged(const QString &)));
 }
 
 StandardParamConfig::~StandardParamConfig()
 {
+}
+
+void StandardParamConfig::allParamsAdded(void)
+{
+    ui.verticalLayout->addStretch();
 }
 
 void StandardParamConfig::addRange(QString title, QString description, QString param, double min, double max, double increment)
@@ -90,5 +96,37 @@ void StandardParamConfig::intValueChanged(QString param, int value)
         this->showNullMAVErrorMessageBox();
     }
     m_uas->getParamManager()->setParameter(1,param,value);
+}
+
+void StandardParamConfig::onSearchFilterChanged(const QString &searchFilterText)
+{
+    if (searchFilterText.isEmpty())
+    {
+        for (int i = 0; i < ui.verticalLayout->count(); ++i)
+        {
+            QLayoutItem *item = ui.verticalLayout->itemAt(i);
+            if (item && item->widget())
+            {
+                item->widget()->setVisible(true);
+            }
+        }
+    }
+    else
+    {
+        QStringList filterList = searchFilterText.toLower().split(' ', QString::SkipEmptyParts);
+        for (int i = 0; i < ui.verticalLayout->count(); ++i)
+        {
+            ParamWidget *pw = qobject_cast<ParamWidget *>(ui.verticalLayout->itemAt(i)->widget());
+            if (pw)
+            {
+                bool shouldShow = true;
+                foreach (const QString &filterTerm, filterList)
+                {
+                    shouldShow = shouldShow && pw->matchesSearchFilter(filterTerm);
+                }
+                pw->setVisible(shouldShow);
+            }
+        }
+    }
 }
 

--- a/src/ui/configuration/StandardParamConfig.h
+++ b/src/ui/configuration/StandardParamConfig.h
@@ -36,11 +36,13 @@ public:
     ~StandardParamConfig();
     void addRange(QString title,QString description,QString param,double min,double max,double increment);
     void addCombo(QString title,QString description,QString param,QList<QPair<int,QString> > valuelist);
+    void allParamsAdded(void);
 
 private slots:
     void parameterChanged(int uas, int component, QString parameterName, QVariant value);
     void doubleValueChanged(QString param,double value);
     void intValueChanged(QString param,int value);
+    void onSearchFilterChanged(const QString &searchFilterText);
 
 private:
     QMap<QString,ParamWidget*> paramToWidgetMap;

--- a/src/ui/configuration/StandardParamConfig.ui
+++ b/src/ui/configuration/StandardParamConfig.ui
@@ -15,10 +15,51 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>&lt;h2&gt;Standard Params&lt;/h2&gt;</string>
-     </property>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>&lt;h2&gt;Standard Params&lt;/h2&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="searchFilter">
+        <property name="toolTip">
+         <string>Type words separated by spaces. Only parameters which match all search terms will be displayed.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Filter</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -31,8 +72,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>631</width>
-        <height>505</height>
+        <width>625</width>
+        <height>492</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">


### PR DESCRIPTION
This change adds a filtering box at the top of the "Standard Parameters" and "Advanced Parameters" views. User can type individual terms, separated by spaces in this box. As the user types, the parameters below are filtered to just display the ones that match all terms. This is a bit different than the searching in the "Full Parameter" view, but should still be helpful to narrow down the immense list of parameters.

This pull request is based against master, since I don't think there's anything Qt5-specific in this. I couldn't verify this however, so please test against Qt4.8 first...

(This should address/fix #135)
