### PR TITLE
Linux: Changed busy-serial-port error message to reference modemmanager

### DIFF
--- a/src/ui/configuration/PX4FirmwareUploader.cc
+++ b/src/ui/configuration/PX4FirmwareUploader.cc
@@ -345,7 +345,7 @@ void PX4FirmwareUploader::run()
 #ifdef Q_OS_LINUX
         if(m_port->errorString().contains("busy"))
         {
-            emit statusUpdate("ERROR: Port " + m_port->portName() + " is locked by an external process. Run: \"sudo lsof /dev/" + m_port->portName() + "\" to determine the associated programs. They can usually be uninstalled.");
+            emit statusUpdate("ERROR: Port " + m_port->portName() + " is locked by an external process. Try uninstalling \"modemmanager\" or run: \"sudo lsof /dev/" + m_port->portName() + "\" to determine the interfering application.");
         }
 #endif
         return;

--- a/src/ui/configuration/TerminalConsole.cc
+++ b/src/ui/configuration/TerminalConsole.cc
@@ -238,7 +238,7 @@ void TerminalConsole::openSerialPort(const SerialSettings &settings)
 #ifdef Q_OS_LINUX
         if(m_serial->errorString().contains("busy"))
         {
-            errorMessage = tr("ERROR: Port ") + m_serial->portName() + tr(" is locked by an external process. Run: \"sudo lsof /dev/") + m_serial->portName() + tr("\" to determine the associated programs. They can usually be uninstalled.");
+            errorMessage = tr("ERROR: Port ") + m_serial->portName() + tr(" is locked by an external process. Try uninstalling \"modemmanager\" or run: \"sudo lsof /dev/") + m_serial->portName() + tr("\" to determine the interfering application.");
         }
 #endif
 


### PR DESCRIPTION
As per #289, fixed the "busy serial port" error message to recommend that the user uninstall modem-manager
