### PR TITLE
Linux: fixed compilation errors in Ubuntu 14.04

### DIFF
--- a/src/QGC.h
+++ b/src/QGC.h
@@ -50,12 +50,6 @@ inline bool isinf(T value)
 }
 #else
 #include <cmath>
-#ifndef isnan
-#define isnan(x) std::isnan(x)
-#endif
-#ifndef isinf
-#define isinf(x) std::isinf(x)
-#endif
 #endif
 
 namespace QGC


### PR DESCRIPTION
Fix for issue #317 by removing references to std::isnan and std::isinf and instead using direct from the <cmath> header.
It compiles OK on both Ubuntu 13 and 14.
As this change affects the MacOS build, someone will want to check this patch doesn't break it.
