### PR TITLE
Linux: Fixed auto-updater not detecting OS correctly

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -29,9 +29,23 @@ message(Qt version $$[QT_VERSION])
 # to allow us to easily modify suported build types in one place instead of duplicated throughout
 # the project file.
 
-linux-g++ | linux-g++-64 {
-    message(Linux build)
+linux-g++-64 {
+    message(Linux build x64_86)
     CONFIG += LinuxBuild
+    DEFINES += Q_LINUX_64
+    DISTRO = $$system(lsb_release -i)
+    contains( DISTRO, "Ubuntu" ) {
+         DEFINES += Q_UBUNTU
+    }
+} else: linux-g++ {
+    message(Linux build x86)
+    CONFIG += LinuxBuild
+    DEFINES += Q_LINUX_32
+    DISTRO = $$system(lsb_release -i)
+    contains( DISTRO, "Ubuntu" ) {
+         DEFINES += Q_UBUNTU
+    }
+
 } else : win32-msvc2008 | win32-msvc2010 | win32-msvc2012 {
     message(Windows build)
     CONFIG += WindowsBuild

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -30,8 +30,14 @@
 
 #ifdef Q_OS_MACX
 #define APP_PLATFORM "osx"
-#elif defined(Q_OS_UNIX)
-#define APP_PLATFORM "debian"
+#elif defined(Q_LINUX_64) && defined(Q_UBUNTU)
+#define APP_PLATFORM "ubuntu64"
+#elif defined(Q_LINUX_64)
+#define APP_PLATFORM "debian64"
+#elif defined(Q_OS_LINUX) && defined(Q_UBUNTU)
+#define APP_PLATFORM "ubuntu32"
+#elif defined(Q_OS_LINUX)
+#define APP_PLATFORM "debian32"
 #else
 #define APP_PLATFORM "win"
 #endif


### PR DESCRIPTION
Fix for #325. Autoupdater will detect the correct distro and 32/64bit-ness of the host system.

Note this is done via defines at build time, thus we are assuming no cross-compilation. The pbuilder used to compile the release versions should manage the build defines correctly though.
