### PR TITLE
Settings for TCP and UDP links set to a minimum port number of 1000

### DIFF
--- a/src/ui/QGCTCPLinkConfiguration.ui
+++ b/src/ui/QGCTCPLinkConfiguration.ui
@@ -27,7 +27,7 @@
    <item row="0" column="1">
     <widget class="QSpinBox" name="portSpinBox">
      <property name="minimum">
-      <number>3000</number>
+      <number>1000</number>
      </property>
      <property name="maximum">
       <number>100000</number>

--- a/src/ui/QGCUDPLinkConfiguration.ui
+++ b/src/ui/QGCUDPLinkConfiguration.ui
@@ -24,7 +24,7 @@
    <item row="0" column="1">
     <widget class="QSpinBox" name="portSpinBox">
      <property name="minimum">
-      <number>3000</number>
+      <number>1000</number>
      </property>
      <property name="maximum">
       <number>100000</number>


### PR DESCRIPTION
Fix for #337. Lowered minimum port number from 3000 to 1000 for TCP and UDP links
