### PR TITLE
Crash when replaying tlog file

### DIFF
--- a/src/ui/WaypointList.cc
+++ b/src/ui/WaypointList.cc
@@ -386,6 +386,7 @@ void WaypointList::currentWaypointEditableChanged(quint16 seq)
             for(int i = 0; i < waypoints.count(); i++)
             {
                 WaypointEditableView* widget = wpEditableViews.find(waypoints[i]).value();
+                if (!widget) continue;
 
                 if (waypoints[i]->getId() == seq)
                 {
@@ -412,6 +413,7 @@ void WaypointList::currentWaypointViewOnlyChanged(quint16 seq)
         for(int i = 0; i < waypoints.count(); i++)
         {
             WaypointViewOnlyView* widget = wpViewOnlyViews.find(waypoints[i]).value();
+            if (!widget) continue;
 
             if (waypoints[i]->getId() == seq)
             {


### PR DESCRIPTION
```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   com.diydrones.apmplanner2       0x000000010d67c48d WaypointEditableView::setCurrent(bool) + 29 (WaypointEditableView.cc:635)
1   com.diydrones.apmplanner2       0x000000010d530e36 WaypointList::currentWaypointEditableChanged(unsigned short) + 230 (WaypointList.cc:393)
2   com.diydrones.apmplanner2       0x000000010d530e94 WaypointList::currentWaypointViewOnlyChanged(unsigned short) + 36 (WaypointList.cc:408)
3   com.diydrones.apmplanner2       0x000000010d94eefc WaypointList::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) + 604 (moc_WaypointList.cpp:111)
```

Not sure how this can actually happen... but at least this patch prevents APM from crashing,
