### PR TITLE
Remove redunancy in map type menu generation (add Google Terrain and others)

### DIFF
--- a/src/ui/map/QGCMapToolBar.cc
+++ b/src/ui/map/QGCMapToolBar.cc
@@ -19,6 +19,24 @@ QGCMapToolBar::QGCMapToolBar(QWidget *parent) :
     ui->setupUi(this);
 }
 
+static const struct {
+    const char*    name;
+    MapType::Types type;
+} sMapTypes[] = {
+    { "Bing Hybrid", MapType::BingHybrid },
+    { "Bing Map", MapType::BingMap },
+    { "Bing Satellite", MapType::BingSatellite },
+    { "Google Hybrid", MapType::GoogleHybrid },
+    { "Google Map", MapType::GoogleMap },
+    { "Google Satellite", MapType::GoogleSatellite },
+    { "Google Terrain", MapType::GoogleTerrain },
+    { "OpenStreetMap", MapType::OpenStreetMap },
+    { "ArcGIS Map", MapType::ArcGIS_Map },
+    { "ArcGIS Terrain", MapType::ArcGIS_Terrain }
+};
+
+static const size_t sNumMapTypes = sizeof(sMapTypes) / sizeof(sMapTypes[0]);
+
 void QGCMapToolBar::setMap(QGCMapWidget* map)
 {
     this->map = map;
@@ -62,51 +80,14 @@ void QGCMapToolBar::setMap(QGCMapWidget* map)
         //setup the mapTypesMenu
         QAction* action;
         MapType::Types mapType = map->GetMapType();
-
-        action =  mapTypesMenu.addAction(tr("Bing Hybrid"),this,SLOT(setMapType()));
-        action->setData(MapType::BingHybrid);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::BingHybrid) action->setChecked(true);
-
-        action =  mapTypesMenu.addAction(tr("Bing Map"),this,SLOT(setMapType()));
-        action->setData(MapType::BingMap);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::BingMap) action->setChecked(true);
-
-        action =  mapTypesMenu.addAction(tr("Bing Satellite"),this,SLOT(setMapType()));
-        action->setData(MapType::BingSatellite);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::BingSatellite) action->setChecked(true);
-
-        action =  mapTypesMenu.addAction(tr("Google Hybrid"),this,SLOT(setMapType()));
-        action->setData(MapType::GoogleHybrid);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::GoogleHybrid) action->setChecked(true);
-
-        action =  mapTypesMenu.addAction(tr("Google Map"),this,SLOT(setMapType()));
-        action->setData(MapType::GoogleMap);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::GoogleMap) action->setChecked(true);
-
-        action =  mapTypesMenu.addAction(tr("Google Satellite"),this,SLOT(setMapType()));
-        action->setData(MapType::GoogleSatellite);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::GoogleSatellite) action->setChecked(true);
-
-        action =  mapTypesMenu.addAction(tr("OpenStreetMap"),this,SLOT(setMapType()));
-        action->setData(MapType::OpenStreetMap);
-        action->setCheckable(true);
-        mapTypesGroup->addAction(action);
-        if(mapType == MapType::OpenStreetMap) action->setChecked(true);
-
+        for (size_t i = 0; i < sNumMapTypes; ++i) {
+            action = mapTypesMenu.addAction(tr(sMapTypes[i].name), this, SLOT(setMapType()));
+            action->setData(sMapTypes[i].type);
+            action->setCheckable(true);
+            mapTypesGroup->addAction(action);
+            if (mapType == sMapTypes[i].type) action->setChecked(true);
+        }
         optionsMenu.addMenu(&mapTypesMenu);
-
 
         // FIXME MARK CURRENT VALUES IN MENU
         QAction *defaultTrailAction = trailPlotMenu.addAction(tr("No trail"), this, SLOT(setUAVTrailTime()));


### PR DESCRIPTION
Upon seeing the new options, I decided to add Google Terrain... and then refactored the code to get rid of duplication.  It is now data-driven and easy to add any other supported map types from opmapcontrol.
