### PR TITLE
Fix the main problem with dataflash downloads

### DIFF
--- a/src/uas/LogDownloadDialog.cc
+++ b/src/uas/LogDownloadDialog.cc
@@ -39,7 +39,7 @@ LogDownloadDescriptor::LogDownloadDescriptor(uint logID, uint time_utc,
                                              uint logSize)
 {
     m_logID = logID;
-    m_logTimeUTC = QDateTime::fromMSecsSinceEpoch(time_utc);
+    m_logTimeUTC = QDateTime::fromTime_t(time_utc);
     // Set time to current UTC time if time is 1970 i.e. invalid.
     if(m_logTimeUTC.date().year() == 1970)
         m_logTimeUTC = QDateTime::currentDateTimeUtc();


### PR DESCRIPTION
Function was expecting time in milliseconds, getting seconds. Year is then 1970, and triggers the "invalid date" checker. Then multiple logs are saved with same filename and overwritten.

This can be merged now, but I'm also working on a change which prevents accidental overwriting of log files in any situation. If this isn't merged then I'll use the same PR, otherwise I'll open a new one.

Closes #350 and #347 .
