### PR TITLE
Fix view of float/double values in QuickView

### DIFF
--- a/src/ui/uas/UASQuickView.cc
+++ b/src/ui/uas/UASQuickView.cc
@@ -374,7 +374,7 @@ void UASQuickView::valueUpdate(const int uasId,const QString &name,const QString
 
 void UASQuickView::valueChanged(const int uasId, const QString& name, const QString& unit, const QVariant& value, const quint64 msec)
 {
-    if (value.type() == QVariant::Double)
+    if ((QMetaType::Type)value.type() == QMetaType::Double || (QMetaType::Type)value.type() == QMetaType::Float)
     {
         valueChanged(uasId,name,unit,value.toDouble(),msec);
     }


### PR DESCRIPTION
Many values in QuickView were in fact of type "float" not "double" and so were truncating to ints and being displayed without their fractional parts.  This fixes that.
