### PR TITLE
Broadcast estimated battery time remaining

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -569,8 +569,9 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
             emit batteryChanged(this, lpVoltage, currentCurrent, getChargeLevel(), timeRemaining);
             // emit voltageChanged(message.sysid, currentVoltage);
 
-            emit valueChanged(uasId, name.arg("Battery"), "%", state.battery_remaining, time);
-            emit valueChanged(uasId, name.arg("Voltage"), "V", state.voltage_battery/1000.0f, time);
+            emit valueChanged(uasId, name.arg("Battery"), "%", getChargeLevel(), time);
+            emit valueChanged(uasId, name.arg("Voltage"), "V", tickLowpassVoltage, time);
+            emit valueChanged(uasId, name.arg("Batt Time Remaining"), "s", timeRemaining, time);
 
 			// And if the battery current draw is measured, log that also.
 			if (state.current_battery != -1)


### PR DESCRIPTION
Use better, more useful numbers when broadcasting battery info in QuickView -- use filtered charge level estimate and battery voltage, and also broadcast estimated charge time remaining.
