### PR TITLE
Better battery calcs

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -559,7 +559,11 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
                 lastTickVoltageValue = tickLowpassVoltage;
             }
 
-            if (startVoltage < currentVoltage && currentVoltage > 0.1f) startVoltage = currentVoltage;
+            if (startVoltage < currentVoltage && currentVoltage > 0.1f)
+            {
+                startVoltage = currentVoltage;
+                startTime = QGC::groundTimeMilliseconds();
+            }
             timeRemaining = calculateTimeRemaining();
             if (!batteryRemainingEstimateEnabled && chargeLevel != -1)
             {


### PR DESCRIPTION
Some changes to how battery time-remaining is calculated under fluctuating readings.
- First, use low-pass filtered voltage for the calculations
- Second, do not rely on the first voltage reading above -1.0V as being definitive.  In practice I sometimes see that initial reading be way low, leading to screwy calculations.  Instead, now any time I see a higher voltage, we reset startVoltage.  As I'm typing this note, I'm thinking that actually you could potentially get a really big spiky high voltage, which would screw things up too.  But this is I think at least better than the current system.  Ideally actually we'd keep a rolling window to do better estimation based on recent power consumption, rather than estimate future power consumption based on all of history, which history likely includes a power-sucking takeoff which won't actually likely recur during the rest of the flight...
