### PR TITLE
Fix to undo tautological code

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -280,7 +280,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 {
                     if (lastIndex.value(message.sysid).contains(message.compid))
                     {
-                        if (lastIndex.value(message.sysid).value(message.compid) == -1)
+                        if (lastIndex.value(message.sysid).value(message.compid) == (uint8_t)-1)
                         {
                             lastIndex[message.sysid][message.compid] = message.seq;
                             expectedIndex = message.seq;


### PR DESCRIPTION
You need to explicitly cast (-1) to be uint8_t or else the compiler will realize that the LHS of the if can never be -1 and will just remove the if statement.
