### PR TITLE
Don't return a reference to a temporary stack variable, that's bad joojoo

### DIFF
--- a/src/ui/DroneshareAPIBroker.cpp
+++ b/src/ui/DroneshareAPIBroker.cpp
@@ -97,7 +97,7 @@ void DroneshareAPIBroker::addBaseUrl(const QString &baseUrl)
     m_droneshareBaseUrl = baseUrl;
 }
 
-const QString& DroneshareAPIBroker::getUrl() const
+const QString DroneshareAPIBroker::getUrl() const
 {
     return m_url.toString();
 }

--- a/src/ui/DroneshareAPIBroker.h
+++ b/src/ui/DroneshareAPIBroker.h
@@ -43,7 +43,7 @@ public:
     void addQuery(const QString& queryString);
     void addQueryItem(const QString& key, const QString& value);
     void sendQueryRequest();
-    const QString& getUrl() const;
+    const QString getUrl() const;
 
 signals:
     void queryFailed(const QString& errorString);


### PR DESCRIPTION
Don't return a ref to a QString which is on the stack and will be gone by the time the caller gets it.
