### PR TITLE
Build: Add qmake stash file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ deploy/*.exe
 deploy/*.list
 *.exe
 deploy/*.dll
+.qmake.stash


### PR DESCRIPTION
Dunno if .qmake.stash is Qt5-specific, but there's no harm adding it to .git-ignore anyway
