### PR TITLE
Setting default extension(.txt) when saving WP

### DIFF
--- a/src/ui/WaypointList.cc
+++ b/src/ui/WaypointList.cc
@@ -204,7 +204,7 @@ void WaypointList::setUAS(UASInterface* uas)
 void WaypointList::saveWaypoints()
 {
 
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save File"), QGC::appDataDirectory(), tr("Waypoint File (*.txt)"));
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save File"), QGC::appDataDirectory() + "/mission.txt", tr("Waypoint File (*.txt)"));
     QApplication::processEvents(); // Removes the dialog from screen
     WPM->saveWaypoints(fileName);
 


### PR DESCRIPTION
Based on definitions found in src/configuration.h the use of backslash should work for windows users as well ?
- I failed to find a OS-dependent "/" or "\" use elsewhere.
