### PR TITLE
Fix log pull

### DIFF
--- a/src/ui/configuration/LogConsole.h
+++ b/src/ui/configuration/LogConsole.h
@@ -54,6 +54,7 @@ private slots:
     void dumpFileStart(QString);
     void dumpFileFinish(QString);
     void dumpFileBytesRead(long);
+    void dumpFileStatusMsg(QString);
     void workerStopped();
     void workerCancelled();
 
@@ -101,6 +102,7 @@ signals:
     void startFile(QString);
     void finishFile(QString);
     void bytesRead(long);
+    void statusMsg(QString);
     void finishAll();
     void error(QString);
     void cancelled();


### PR DESCRIPTION
I noticed trying to pull logs with ArduCopter 3.2 was mostly unreliable. Changed the line handling so it waits until it sees the first line that _should_ be in a log file before starting to collect lines to write to the log file, and keeps collecting until it sees the "Logs]" line. This seems hack-ish and perhaps there's a more deterministic way to read logs, but this is the best I came up with. Please try it and verify it works for you. Thanks.
