### PR TITLE
migrated to Qt 5.3.2

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -106,7 +106,10 @@ QT += network \
     widgets \
     serialport \
     webkitwidgets \
-    script
+    script  \
+    printsupport \
+    qml \
+    quick
 
 ##  testlib is needed even in release flavor for QSignalSpy support
 QT += testlib

--- a/src/ui/ApmToolBar.h
+++ b/src/ui/ApmToolBar.h
@@ -33,7 +33,11 @@ This file is part of the APM_PLANNER project
 
 #include "UASInterface.h"
 #include <QAction>
+#if QT_VERSION >= 0x050302
+#include <QtQuick/QQuickView>
+#else
 #include <QQuickView>
+#endif
 
 class QTimer;
 

--- a/src/ui/PrimaryFlightDisplayQML.h
+++ b/src/ui/PrimaryFlightDisplayQML.h
@@ -25,7 +25,11 @@ This file is part of the APM_PLANNER project
 
 #include <UASInterface.h>
 #include <QWidget>
+#if QT_VERSION >= 0x050302
+#include <QtQuick/QQuickView>
+#else
 #include <QQuickView>
+#endif
 
 namespace Ui {
 class PrimaryFlightDisplayQML;

--- a/src/ui/qcustomplot.h
+++ b/src/ui/qcustomplot.h
@@ -46,10 +46,10 @@
 #include <qmath.h>
 #include <limits>
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#  include <qnumeric.h>
-#  include <QPrinter>
+#include <qnumeric.h>
+#include <QPrinter>
 #else
-#  include <QtNumeric>
+#include <QtNumeric>
 #include <QtPrintSupport/QtPrintSupport>
 #endif
 


### PR DESCRIPTION
apm_planner might tested only for Qt 5.2.1, and there is Qt 5.3.2 for ArchLinux, KDE developers mainly use it ;)
so I simply added QT_VERSION 0x050302 check.
