### PR TITLE
Update qgroundcontrol.pro

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -106,7 +106,9 @@ QT += network \
     widgets \
     serialport \
     webkitwidgets \
-    script
+    script \
+    quick \
+    printsupport
 
 ##  testlib is needed even in release flavor for QSignalSpy support
 QT += testlib


### PR DESCRIPTION
fix issuses:
- src/ui/ApmToolBar.h: #include <QQuickView> no such file or directory
- link error due to libQt5PrintSupport

when compiled with Qt 5.3.2 and g++ 4.9.1 on debian sid
