### PR TITLE
Log Console: fix SIGSEGV

### DIFF
--- a/src/ui/configuration/LogConsole.cc
+++ b/src/ui/configuration/LogConsole.cc
@@ -175,8 +175,6 @@ void Worker::onLineRead(char *data) {
 
 void Worker::readData() {
     char line[256];
-    QWaitCondition waitCondition;
-    QMutex mutex;
 
     while(m_port->canReadLine() && m_run) {
         int len = m_port->readLine(line, 256);
@@ -189,10 +187,6 @@ void Worker::readData() {
         else {
             onLineRead(line);
         }
-
-        // Oddly, this seems necessary.
-        // It segfaults otherwise.
-        waitCondition.wait(&mutex, 2);
 
         if(!m_run) {
             onCancel();


### PR DESCRIPTION
Here's the relevant crash dump:

```
Process:         apmplanner2 [95534]
Path:            /Users/USER/*/apmplanner2.app/Contents/MacOS/apmplanner2
Identifier:      com.diydrones.apmplanner2
Version:         0
Code Type:       X86-64 (Native)
Parent Process:  bash [437]
Responsible:     Terminal [339]
User ID:         502

Date/Time:       2014-11-04 12:07:01.489 -0500
OS Version:      Mac OS X 10.9.5 (13F34)
Report Version:  11
Anonymous UUID:  0A57166C-FC94-DE2C-41BF-22A396B2D50E

Sleep/Wake UUID: B5318D96-1E26-468B-89F6-C039235C2D73

Crashed Thread:  20  QThread

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x000000000000000c


Thread 20 Crashed:: QThread
0   QtCore                          0x000000010258bdb2 QBasicMutex::unlockInternal() + 18
1   QtCore                          0x000000010258b67c QMutex::unlock() + 44
2   QtCore                          0x000000010259402d QWaitCondition::wait(QMutex*, unsigned long) + 157
3   com.diydrones.apmplanner2       0x0000000100b422c9 Worker::readData() + 1353 (LogConsole.cc:196)
4   com.diydrones.apmplanner2       0x0000000100cebc3c Worker::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) + 572 (moc_LogConsole.cpp:315)
5   QtCore                          0x000000010275f6c3 QObject::event(QEvent*) + 755
6   QtWidgets                       0x000000010558022c QApplicationPrivate::notify_helper(QObject*, QEvent*) + 252
7   QtWidgets                       0x00000001055818fa QApplication::notify(QObject*, QEvent*) + 1050
8   QtCore                          0x0000000102735d84 QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) + 1044
9   QtCore                          0x0000000102788ab8 postEventSourceDispatch(_GSource*, int (*)(void*), void*) + 24
10  libglib-2.0.0.dylib             0x0000000107bf0b4d g_main_context_dispatch + 274
11  libglib-2.0.0.dylib             0x0000000107bf0e3b g_main_context_iterate + 413
12  libglib-2.0.0.dylib             0x0000000107bf0e93 g_main_context_iteration + 55
13  QtCore                          0x0000000102787fb3 QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) + 99
14  QtCore                          0x000000010273270d QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 381
15  QtCore                          0x000000010258ee45 QThread::exec() + 117
16  QtCore                          0x0000000102592a19 QThreadPrivate::start(void*) + 313
17  libsystem_pthread.dylib         0x00007fff995bd899 _pthread_body + 138
18  libsystem_pthread.dylib         0x00007fff995bd72a _pthread_start + 137
19  libsystem_pthread.dylib         0x00007fff995c1fc9 thread_start + 13

Thread 20 crashed with X86 Thread State (64-bit):
  rax: 0x00000000fff00000  rbx: 0x000000010b35b4d8  rcx: 0x0000000000000000  rdx: 0x000000010282dfb3
  rdi: 0x000000010b35b4d8  rsi: 0x000000010282e07f  rbp: 0x000000010b35b310  rsp: 0x000000010b35b2f0
   r8: 0x00007fd256827e40   r9: 0x00007fd256b542a0  r10: 0x000000005001a0c2  r11: 0x000000000e9c2161
  r12: 0x00007fd251c20330  r13: 0x00007fd256ac9600  r14: 0x0000000000000002  r15: 0x0000000000000000
  rip: 0x000000010258bdb2  rfl: 0x0000000000010297  cr2: 0x000000000000000c

Logical CPU:     0
Error Code:      0x00000006
Trap Number:     14


Binary Images:
       0x100558000 -        0x10131ffff +com.diydrones.apmplanner2 (0) <7B02B577-CC5C-384E-A28A-B7E282BE1DCD> /Users/USER/*/apmplanner2.app/Contents/MacOS/apmplanner2
       0x101a8c000 -        0x101b53fff +org.libsdl.SDL2 (2.0.3 - 2.0.3) <78D9C537-E977-3AD1-9890-53FBC62A4D69> /Users/USER/*/apmplanner2.app/Contents/Frameworks/SDL2.framework/Versions/A/SDL2
       0x101b76000 -        0x101e2fff7 +QtQuick (5.3.2) <11BB5DE6-889A-31F7-9B69-33132FE43979> /opt/local/Library/Frameworks/QtQuick.framework/Versions/5/QtQuick
       0x101f8a000 -        0x1022b9fff +QtQml (5.3.2) <226F5B38-544C-3CAD-8D27-F39AD5FF8A7B> /opt/local/Library/Frameworks/QtQml.framework/Versions/5/QtQml
       0x1023ee000 -        0x1024f4fff +QtNetwork (5.3.2) <32AC9E4D-287E-34F1-A46B-BE1A8F9F812C> /opt/local/Library/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
       0x10255f000 -        0x102991ff7 +QtCore (5.3.2) <31D135F3-7156-3180-A781-AB3AE9289F2E> /opt/local/Library/Frameworks/QtCore.framework/Versions/5/QtCore
       0x102a7b000 -        0x102e49ff7 +QtGui (5.3.2) <6075AD18-284D-339A-8FE7-513B42EF8D30> /opt/local/Library/Frameworks/QtGui.framework/Versions/5/QtGui
       0x102f6a000 -        0x102f97fff +QtWebKitWidgets (5.3.2) <D9EC6EAC-ADDC-333B-AA11-6F1CBFE0DA14> /opt/local/Library/Frameworks/QtWebKitWidgets.framework/Versions/5/QtWebKitWidgets
       0x102fc4000 -        0x1049a8fff +QtWebKit (5.3.2) <D99D573F-5D15-33FB-81DA-23300EE0152F> /opt/local/Library/Frameworks/QtWebKit.framework/Versions/5/QtWebKit
       0x105553000 -        0x105a1bfff +QtWidgets (5.3.2) <6E77C8AE-7A78-3844-B00B-9EFAF01FEB8A> /opt/local/Library/Frameworks/QtWidgets.framework/Versions/5/QtWidgets
       0x105bc1000 -        0x105bf4fff +QtPrintSupport (5.3.2) <0235205D-12D7-3DB7-AE9E-703268F580C6> /opt/local/Library/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
       0x105c22000 -        0x105c5aff7 +QtSvg (5.3.2) <7DA00750-D87E-3E49-9E89-E0F4156F5AAD> /opt/local/Library/Frameworks/QtSvg.framework/Versions/5/QtSvg
       0x105c78000 -        0x105cb5fff +QtOpenGL (5.3.2) <B32ED24F-AE5D-3858-AAB2-6622827CBF1E> /opt/local/Library/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL
       0x105cdd000 -        0x105d6fff7 +QtMultimedia (5.3.2) <F6F74618-FE3F-3F44-A6BB-76F794021BC9> /opt/local/Library/Frameworks/QtMultimedia.framework/Versions/5/QtMultimedia
       0x105dd4000 -        0x105df9fff +QtTest (5.3.2) <85898693-2611-39BC-B068-BABFB1CB4CE6> /opt/local/Library/Frameworks/QtTest.framework/Versions/5/QtTest
       0x105e10000 -        0x105faefff +QtScript (5.3.2) <D355F5BF-B706-33BA-9FA2-1B67F9D1F86A> /opt/local/Library/Frameworks/QtScript.framework/Versions/5/QtScript
       0x106055000 -        0x106065fff +QtSerialPort (5.3.2) <C8136D32-4986-3197-8691-BE3F1AB28C09> /opt/local/Library/Frameworks/QtSerialPort.framework/Versions/5/QtSerialPort
       0x106075000 -        0x10609efff +QtSql (5.3.2) <F76579B3-788E-3961-A752-EBF1BE2D0D6A> /opt/local/Library/Frameworks/QtSql.framework/Versions/5/QtSql
       0x1060b5000 -        0x1060b8ff7 +libqtquick2plugin.dylib (0) <57238C2D-E66A-35CE-B999-AA643D1F7D3C> /opt/local/share/*/libqtquick2plugin.dylib
       0x1060bc000 -        0x1060f4ff7 +QtXml (5.3.2) <E9682BD2-C3CE-3320-AFCC-9B2C9100D4BC> /opt/local/Library/Frameworks/QtXml.framework/Versions/5/QtXml
       0x10610e000 -        0x106112fff  com.apple.agl (3.2.3 - AGL-3.2.3) <9851E4CC-DA6B-3AF4-9B06-61BAC289572D> /System/Library/Frameworks/AGL.framework/Versions/A/AGL
       0x10611f000 -        0x106121fff  com.apple.ForceFeedback (1.0.6 - 1.0.6) <D21AD43F-147B-3B50-89AB-26695EB89998> /System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback
       0x106128000 -        0x106137ff7 +libz.1.dylib (0) <1E1D6754-570B-3DBE-A654-8812B2A95A65> /opt/local/lib/libz.1.dylib
       0x106140000 -        0x106182fff +libssl.1.0.0.dylib (0) <28E08560-36E4-3F0F-A819-D128200FF3E7> /opt/local/lib/libssl.1.0.0.dylib
       0x1061a0000 -        0x1062bafff +libcrypto.1.0.0.dylib (0) <39FCE835-0A2D-3937-9E3E-A7571CC1707C> /opt/local/lib/libcrypto.1.0.0.dylib
       0x10632f000 -        0x1064a2fff +libicui18n.53.dylib (0) <01778C4B-C1E8-34F9-A3CD-E3D110CECA63> /opt/local/lib/libicui18n.53.dylib
       0x106569000 -        0x10666afff +libicuuc.53.dylib (0) <22BA3E43-4BFA-3836-9FAF-F0BEDDBAB309> /opt/local/lib/libicuuc.53.dylib
       0x1066d0000 -        0x107b57fff +libicudata.53.dylib (0) <E1130698-7B98-3D91-A4F8-7878338A3213> /opt/local/lib/libicudata.53.dylib
       0x107b5c000 -        0x107bb6fff +libpcre16.0.dylib (0) <C7ACD10D-DCBE-3838-BEDE-2544C0B30E86> /opt/local/lib/libpcre16.0.dylib
       0x107bbc000 -        0x107bbefff +libgthread-2.0.0.dylib (0) <3DE01AD8-0C79-3AC4-8CDC-095B495AD67E> /opt/local/lib/libgthread-2.0.0.dylib
       0x107bc3000 -        0x107cb3ff7 +libglib-2.0.0.dylib (0) <B312B63C-436B-3348-A78D-4F46BEC11E0A> /opt/local/lib/libglib-2.0.0.dylib
       0x107cdf000 -        0x107ce8fff +libintl.8.dylib (0) <4BF02119-B670-3338-BFBB-E0029EDEE5D4> /opt/local/lib/libintl.8.dylib
       0x107cf2000 -        0x107de5ff7 +libiconv.2.dylib (0) <103D57C8-BE15-3BF8-BDBE-53EDBDD0B6A4> /opt/local/lib/libiconv.2.dylib
       0x107df2000 -        0x107e15ff7 +libpng16.16.dylib (0) <4CADB16D-4930-3AF7-809F-BF88387C009F> /opt/local/lib/libpng16.16.dylib
       0x107e21000 -        0x107e35ff7 +QtMultimediaWidgets (5.3.2) <13D8E536-4C2D-3E6B-9352-A416F231350E> /opt/local/Library/Frameworks/QtMultimediaWidgets.framework/Versions/5/QtMultimediaWidgets
       0x107e48000 -        0x107e80fff +QtPositioning (5.3.2) <98E3F898-33D1-3749-B134-07C7283347D9> /opt/local/Library/Frameworks/QtPositioning.framework/Versions/5/QtPositioning
       0x107e99000 -        0x107eb9fff +QtSensors (5.3.2) <37D4669B-62B4-3301-B55B-6CF0E89A0B8C> /opt/local/Library/Frameworks/QtSensors.framework/Versions/5/QtSensors
       0x107edb000 -        0x107f08ff7 +libjpeg.9.dylib (0) <08C3C5E3-8C99-3CCB-9A9E-15BF05CBB9F3> /opt/local/lib/libjpeg.9.dylib
       0x107ff6000 -        0x107ffbfff +libqico.dylib (0) <49B7C1C3-2CC0-3179-9B66-1A64983E1C40> /opt/local/share/*/libqico.dylib
       0x10a749000 -        0x10a7eefff +libqcocoa.dylib (0) <0FD41C0A-3DD5-305F-B77C-2E66480FA667> /opt/local/share/*/libqcocoa.dylib
       0x10ab0d000 -        0x10ab15fff +libqdds.dylib (0) <5E3D209A-7D7B-39C0-A2A1-4B5DCD461019> /opt/local/share/*/libqdds.dylib
       0x10ab1a000 -        0x10ab20ff7 +libqgif.dylib (0) <1D57D8DF-9764-3FD9-AA23-5DF4438C1D78> /opt/local/share/*/libqgif.dylib
       0x10ab25000 -        0x10ab2cff7 +libqicns.dylib (0) <845600FF-80C9-309E-B233-DC6878453308> /opt/local/share/*/libqicns.dylib
       0x10ab32000 -        0x10abb8fff +libqjp2.dylib (0) <088A541D-6BE2-3B45-91BD-59ACDBE6DB54> /opt/local/share/*/libqjp2.dylib
       0x10abd0000 -        0x10abd7fff +libqjpeg.dylib (0) <7549A395-B513-3645-8DF3-2CF58F77422D> /opt/local/share/*/libqjpeg.dylib
       0x10abdd000 -        0x10abe2fff +libqmng.dylib (0) <67CD7ECE-2D5F-3206-BAB9-0E74BA93935B> /opt/local/share/*/libqmng.dylib
       0x10abe8000 -        0x10ac28fff +libmng.1.dylib (0) <0C54D536-B1C9-3C75-A767-C885E6E71D3D> /opt/local/lib/libmng.1.dylib
       0x10ac3c000 -        0x10ac61fff +liblcms.1.dylib (0) <57DDBC2C-2704-3C78-9193-9B2D7CA3ABBF> /opt/local/lib/liblcms.1.dylib
       0x10ac6e000 -        0x10ac72ff7 +libqsvg.dylib (0) <26A5CEBC-D5E8-3F59-9361-7DFA2FAF818A> /opt/local/share/*/libqsvg.dylib
       0x10ac77000 -        0x10ac7bff7 +libqtga.dylib (0) <09B23419-EB6C-368C-A54B-B8AF598BA7E7> /opt/local/share/*/libqtga.dylib
       0x10ac80000 -        0x10ac86fff +libqtiff.dylib (0) <E71AD172-3A3A-3312-B2E7-A323B8C258DC> /opt/local/share/*/libqtiff.dylib
       0x10ac8b000 -        0x10ace4ff7 +libtiff.5.dylib (0) <562B979F-FC35-3BA6-B105-532AA86A2BBF> /opt/local/lib/libtiff.5.dylib
       0x10acf2000 -        0x10ad0dff7 +liblzma.5.dylib (0) <D2F5A171-C70C-3017-BAD7-1B5ED448DD0D> /opt/local/lib/liblzma.5.dylib
       0x10ad13000 -        0x10ad17ff7 +libqwbmp.dylib (0) <B5828DDB-3FA9-3798-94FD-1BB391B075BE> /opt/local/share/*/libqwbmp.dylib
       0x10ad1c000 -        0x10ad74fff +libqwebp.dylib (0) <0E4A69F4-7E3D-340F-A05F-68C742E5A37A> /opt/local/share/*/libqwebp.dylib
       0x10ade5000 -        0x10adedff7 +libqsvgicon.dylib (0) <ABC839CD-F674-3CBE-B5BD-F89F7CCD97DB> /opt/local/share/*/libqsvgicon.dylib
       0x10da02000 -        0x10da18ff7 +libqcorewlanbearer.dylib (0) <8333E89C-9D1B-3DDC-BB41-BCEAF60E76F0> /opt/local/share/*/libqcorewlanbearer.dylib
       0x10da24000 -        0x10da2dfff +libqgenericbearer.dylib (0) <1E9626A2-86ED-3203-B86C-6D4237B49019> /opt/local/share/*/libqgenericbearer.dylib
       0x11a907000 -        0x11a90bffd  libFontRegistryUI.dylib (127) <57DE4E73-B65B-3712-9815-81018E72501A> /System/Library/Frameworks/ApplicationServices.framework/Frameworks/ATS.framework/Resources/libFontRegistryUI.dylib
       0x11c202000 -        0x11c20aff7 +libqsqlite.dylib (0) <9FB31CCF-FAAC-392F-B896-A29F785BD087> /opt/local/share/*/libqsqlite.dylib
       0x11c213000 -        0x11c2aefff +libsqlite3.0.dylib (0) <1E3FD600-AAD4-3887-91C2-F3EECF759682> /opt/local/lib/libsqlite3.0.dylib
       0x11ecf5000 -        0x11ecf6fe4 +cl_kernels (???) <BCDB02FC-5D74-44A8-BF22-EB34C02AB7F5> cl_kernels
       0x11ed04000 -        0x11ed05ff9 +cl_kernels (???) <E274D9F7-FE0B-4C84-BD01-58AE0DE23A59> cl_kernels
       0x11ed07000 -        0x11ededfef  unorm8_bgra.dylib (2.3.58) <280D6FDD-8CA5-36EC-9EA1-D7DC09598E20> /System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/ImageFormats/unorm8_bgra.dylib
    0x123400000000 -     0x12340047bff7  com.apple.driver.AppleIntelHD4000GraphicsGLDriver (8.28.32 - 8.2.8) <0B941CC0-E86A-3410-B64B-0BCDAD0922B0> /System/Library/Extensions/AppleIntelHD4000GraphicsGLDriver.bundle/Contents/MacOS/AppleIntelHD4000GraphicsGLDriver
    0x123440000000 -     0x123440882ff7  com.apple.GeForceGLDriver (8.26.28 - 8.2.6) <7748942D-BB8D-3ECF-BE8E-ED5AB2F2893B> /System/Library/Extensions/GeForceGLDriver.bundle/Contents/MacOS/GeForceGLDriver
    0x7fff64414000 -     0x7fff64447817  dyld (239.4) <7AD43B9B-5CEA-3C7E-9836-A06909F9CA56> /usr/lib/dyld
    0x7fff8c15f000 -     0x7fff8c160fff  libunc.dylib (28) <62682455-1862-36FE-8A04-7A6B91256438> /usr/lib/system/libunc.dylib
    0x7fff8c161000 -     0x7fff8c18dfff  com.apple.CoreServicesInternal (184.9 - 184.9) <4DEA54F9-81D6-3EDB-AA3C-1F9C497B3379> /System/Library/PrivateFrameworks/CoreServicesInternal.framework/Versions/A/CoreServicesInternal
    0x7fff8c2b3000 -     0x7fff8c2d8ff7  com.apple.CoreVideo (1.8 - 117.2) <4674339E-26D0-35FA-9958-422832B39B12> /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo
    0x7fff8cb9d000 -     0x7fff8d4bc797  com.apple.CoreGraphics (1.600.0 - 599.35.4) <C8CBC664-0CD2-3C7D-A301-9B3BA731250C> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
    0x7fff8e4fd000 -     0x7fff8e519fff  libresolv.9.dylib (54) <11C2C826-F1C6-39C6-B4E8-6E0C41D4FA95> /usr/lib/libresolv.9.dylib
    0x7fff8e51a000 -     0x7fff8e51eff7  libheimdal-asn1.dylib (323.92.1) <CAE21FFF-5763-399C-B7C5-EEBFFEEF2242> /usr/lib/libheimdal-asn1.dylib
    0x7fff8e53d000 -     0x7fff8e56cff9  com.apple.GSS (4.0 - 2.0) <44E914BE-B0D0-3E05-9451-CA9E539AFA52> /System/Library/Frameworks/GSS.framework/Versions/A/GSS
    0x7fff8e56d000 -     0x7fff8e57dffb  libsasl2.2.dylib (170) <C8E25710-68B6-368A-BF3E-48EC7273177B> /usr/lib/libsasl2.2.dylib
    0x7fff8e57e000 -     0x7fff8e5c5ff7  libcups.2.dylib (372.4) <36EA4350-43B4-3A5C-9904-10685BFDA7D4> /usr/lib/libcups.2.dylib
    0x7fff8e5c6000 -     0x7fff8e734ff7  libBLAS.dylib (1094.5) <DE93A590-5FA5-32A2-A16C-5D7D7361769F> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
    0x7fff8e735000 -     0x7fff8e746ff7  libz.1.dylib (53) <42E0C8C6-CA38-3CA4-8619-D24ED5DD492E> /usr/lib/libz.1.dylib
    0x7fff8e747000 -     0x7fff8e98fff7  com.apple.CoreData (107 - 481.3) <E78734AA-E3D0-33CB-A014-620BBCAB2E96> /System/Library/Frameworks/CoreData.framework/Versions/A/CoreData
    0x7fff8e990000 -     0x7fff8e9fcfff  com.apple.framework.IOKit (2.0.1 - 907.100.13) <057FDBA3-56D6-3903-8C0B-849214BF1985> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
    0x7fff8e9fd000 -     0x7fff8e9feff7  libsystem_blocks.dylib (63) <FB856CD1-2AEA-3907-8E9B-1E54B6827F82> /usr/lib/system/libsystem_blocks.dylib
    0x7fff8ea01000 -     0x7fff8ebb9ffb  libicucore.A.dylib (511.35) <6F097DA7-147C-32A1-93D2-728A64CF0DC2> /usr/lib/libicucore.A.dylib
    0x7fff8ebba000 -     0x7fff8ebbeff7  libsystem_stats.dylib (93.90.3) <4E51D5B0-92A0-3D0D-B90E-495A1ED3E391> /usr/lib/system/libsystem_stats.dylib
    0x7fff8ebbf000 -     0x7fff8ec23fff  com.apple.datadetectorscore (5.0 - 354.5) <0AE9749A-6BFC-3032-B802-210DF59AEDB0> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/Versions/A/DataDetectorsCore
    0x7fff8ec24000 -     0x7fff8f005ffe  libLAPACK.dylib (1094.5) <7E7A9B8D-1638-3914-BAE0-663B69865986> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib
    0x7fff8f006000 -     0x7fff8f04bfff  libcurl.4.dylib (78.94.1) <88F27F9B-052E-3375-938D-2603E90D8AD5> /usr/lib/libcurl.4.dylib
    0x7fff8f04c000 -     0x7fff8f074ffb  libRIP.A.dylib (599.35.4) <F3C60582-1F27-335D-9C97-8CF307670F7B> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libRIP.A.dylib
    0x7fff8f32e000 -     0x7fff8f337ffb  libsystem_notify.dylib (121.20.1) <9B34B4FE-F5AD-3F09-A5F0-46AFF3571323> /usr/lib/system/libsystem_notify.dylib
    0x7fff8f338000 -     0x7fff8f376ff7  libGLImage.dylib (9.6.1) <5E02B38C-9F36-39BE-8746-724F0D8BBFC0> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLImage.dylib
    0x7fff8f377000 -     0x7fff8f377fff  com.apple.CoreServices (59 - 59) <7A697B5E-F179-30DF-93F2-8B503CEEEFD5> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
    0x7fff8f378000 -     0x7fff8f382fff  libcommonCrypto.dylib (60049) <8C4F0CA0-389C-3EDC-B155-E62DD2187E1D> /usr/lib/system/libcommonCrypto.dylib
    0x7fff8f383000 -     0x7fff8f385fff  com.apple.EFILogin (2.0 - 2) <C360E8AF-E9BB-3BBA-9DF0-57A92CEF00D4> /System/Library/PrivateFrameworks/EFILogin.framework/Versions/A/EFILogin
    0x7fff8f5d6000 -     0x7fff8f5deff7  com.apple.speech.recognition.framework (4.2.4 - 4.2.4) <98BBB3E4-6239-3EF1-90B2-84EA0D3B8D61> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SpeechRecognition.framework/Versions/A/SpeechRecognition
    0x7fff8f5df000 -     0x7fff8f5ecfff  com.apple.Sharing (132.2 - 132.2) <F983394A-226D-3244-B511-FA51FDB6ADDA> /System/Library/PrivateFrameworks/Sharing.framework/Versions/A/Sharing
    0x7fff8f636000 -     0x7fff8fd85fff  libclh.dylib (4.0.3 - 4.0.3) <FCBB60B6-D389-337F-A930-BDC56F6B34FA> /System/Library/Extensions/GeForceGLDriver.bundle/Contents/MacOS/libclh.dylib
    0x7fff8fdab000 -     0x7fff8fdf9ff7  com.apple.opencl (2.3.59 - 2.3.59) <9F43F471-C3C3-352D-889D-EC418DC1F5B2> /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL
    0x7fff8fdfa000 -     0x7fff8fe23fff  GLRendererFloat (9.6.1) <23A2C705-F932-335D-B27B-565A30333460> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLRendererFloat.bundle/GLRendererFloat
    0x7fff8fe6f000 -     0x7fff8fe9efd2  libsystem_m.dylib (3047.16) <B7F0E2E4-2777-33FC-A787-D6430B630D54> /usr/lib/system/libsystem_m.dylib
    0x7fff8fe9f000 -     0x7fff8ff89fff  libsqlite3.dylib (158) <00269BF9-43BE-39E0-9C85-24585B9923C8> /usr/lib/libsqlite3.dylib
    0x7fff8ff8a000 -     0x7fff8ff8cfff  libCVMSPluginSupport.dylib (9.6.1) <FB37F4C4-1E84-3349-BB03-92CA0A5F6837> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCVMSPluginSupport.dylib
    0x7fff8ffb0000 -     0x7fff8ffbfff8  com.apple.LangAnalysis (1.7.0 - 1.7.0) <8FE131B6-1180-3892-98F5-C9C9B79072D4> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/LangAnalysis.framework/Versions/A/LangAnalysis
    0x7fff9002b000 -     0x7fff9002bfff  com.apple.ApplicationServices (48 - 48) <3E3F01A8-314D-378F-835E-9CC4F8820031> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
    0x7fff9002c000 -     0x7fff9002dffb  libremovefile.dylib (33) <3543F917-928E-3DB2-A2F4-7AB73B4970EF> /usr/lib/system/libremovefile.dylib
    0x7fff900e0000 -     0x7fff9013ffff  com.apple.framework.CoreWLAN (4.3.3 - 433.48) <1F17FA12-6E84-309D-9808-C536D445FA6E> /System/Library/Frameworks/CoreWLAN.framework/Versions/A/CoreWLAN
    0x7fff90142000 -     0x7fff90171fff  com.apple.DebugSymbols (106 - 106) <E1BDED08-523A-36F4-B2DA-9D5C712F0AC7> /System/Library/PrivateFrameworks/DebugSymbols.framework/Versions/A/DebugSymbols
    0x7fff905ee000 -     0x7fff90607ff7  com.apple.Kerberos (3.0 - 1) <F108AFEB-198A-3BAF-BCA5-9DFCE55EFF92> /System/Library/Frameworks/Kerberos.framework/Versions/A/Kerberos
    0x7fff90608000 -     0x7fff9066bffb  com.apple.SystemConfiguration (1.13.1 - 1.13.1) <2C8E1A73-5AD6-3A7D-8ED8-D6755555A993> /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
    0x7fff9066c000 -     0x7fff9079cff7  com.apple.desktopservices (1.8.3 - 1.8.3) <225BEC20-F8E0-3F22-9560-890A1A5B9050> /System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/DesktopServicesPriv
    0x7fff907dc000 -     0x7fff9089eff5  com.apple.CoreText (367.20 - 367.20) <B80D086D-93A9-3C35-860E-9C3FDD027F3B> /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText
    0x7fff908cc000 -     0x7fff908cefff  libRadiance.dylib (1044) <461482C9-CADB-3B36-B023-597C64AD4B00> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libRadiance.dylib
    0x7fff908cf000 -     0x7fff9090afff  com.apple.bom (14.0 - 193.1) <EF24A562-6D3C-379E-8B9B-FAE0E4A0EF7C> /System/Library/PrivateFrameworks/Bom.framework/Versions/A/Bom
    0x7fff9090b000 -     0x7fff90959ff9  libstdc++.6.dylib (60) <0241E6A4-1368-33BE-950B-D0A175C41F54> /usr/lib/libstdc++.6.dylib
    0x7fff90b71000 -     0x7fff90b98ff7  libsystem_network.dylib (241.3) <8B1E1F1D-A5CC-3BAE-8B1E-ABC84337A364> /usr/lib/system/libsystem_network.dylib
    0x7fff90b99000 -     0x7fff90e43ff5  com.apple.HIToolbox (2.1.1 - 698) <A388E773-AE7B-3FD1-8662-A98E6E24EA16> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
    0x7fff90e44000 -     0x7fff90e4ffff  libGPUSupportMercury.dylib (9.6.1) <A34D5C51-28E0-398A-881D-552B47D2DD3C> /System/Library/PrivateFrameworks/GPUSupport.framework/Versions/A/Libraries/libGPUSupportMercury.dylib
    0x7fff90e8b000 -     0x7fff90ed9fff  libcorecrypto.dylib (161.1) <F3973C28-14B6-3006-BB2B-00DD7F09ABC7> /usr/lib/system/libcorecrypto.dylib
    0x7fff916a0000 -     0x7fff916d4fff  libssl.0.9.8.dylib (52) <51C844FF-D7CD-3525-9ABB-84B8DD11D5E4> /usr/lib/libssl.0.9.8.dylib
    0x7fff916d5000 -     0x7fff916d5ffd  libOpenScriptingUtil.dylib (157) <19F0E769-0989-3062-9AFB-8976E90E9759> /usr/lib/libOpenScriptingUtil.dylib
    0x7fff916ed000 -     0x7fff916f4fff  libcompiler_rt.dylib (35) <4CD916B2-1B17-362A-B403-EF24A1DAC141> /usr/lib/system/libcompiler_rt.dylib
    0x7fff916f5000 -     0x7fff91705fff  libbsm.0.dylib (33) <2CAC00A2-1352-302A-88FA-C567D4D69179> /usr/lib/libbsm.0.dylib
    0x7fff9171a000 -     0x7fff91725fff  libGL.dylib (9.6.1) <4B65BF9F-F34A-3CD1-94E8-DB26DAA0A59D> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib
    0x7fff91787000 -     0x7fff917bfff7  com.apple.RemoteViewServices (2.0 - 94) <3F34D630-3DDB-3411-BC28-A56A9B55EBDA> /System/Library/PrivateFrameworks/RemoteViewServices.framework/Versions/A/RemoteViewServices
    0x7fff91ce1000 -     0x7fff91ce4ffc  com.apple.IOSurface (91.1 - 91.1) <D00EEB0C-8AA8-3986-90C1-C97B2486E8FA> /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface
    0x7fff91dab000 -     0x7fff91db7ff7  com.apple.OpenDirectory (10.9 - 173.90.1) <F08601E8-F7E8-3222-AD05-6A26003779CF> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/OpenDirectory
    0x7fff91db8000 -     0x7fff91e9fff7  libxml2.2.dylib (26) <A1DADD11-89E5-3DE4-8802-07186225967F> /usr/lib/libxml2.2.dylib
    0x7fff91f56000 -     0x7fff91f5dff8  liblaunch.dylib (842.92.1) <A40A0C7B-3216-39B4-8AE0-B5D3BAF1DA8A> /usr/lib/system/liblaunch.dylib
    0x7fff91f5e000 -     0x7fff91fcdff1  com.apple.ApplicationServices.ATS (360 - 363.3) <546E89D9-2AE7-3111-B2B8-2366650D22F0> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/ATS
    0x7fff92373000 -     0x7fff92376fff  libCoreVMClient.dylib (58.1) <EBC36C69-C896-3C3D-8589-3E9023E7E56F> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libCoreVMClient.dylib
    0x7fff92377000 -     0x7fff923a8fff  com.apple.MediaKit (15 - 709) <23E33409-5C39-3F93-9E73-2B0E9EE8883E> /System/Library/PrivateFrameworks/MediaKit.framework/Versions/A/MediaKit
    0x7fff923a9000 -     0x7fff923bbff7  com.apple.MultitouchSupport.framework (245.13.1 - 245.13.1) <38262B92-C63F-35A0-997D-AD2EBF2F8338> /System/Library/PrivateFrameworks/MultitouchSupport.framework/Versions/A/MultitouchSupport
    0x7fff923bc000 -     0x7fff923bfff7  libdyld.dylib (239.4) <7C9EC3B7-DDE3-33FF-953F-4067C743951D> /usr/lib/system/libdyld.dylib
    0x7fff923eb000 -     0x7fff923ebfff  com.apple.Cocoa (6.8 - 20) <E90E99D7-A425-3301-A025-D9E0CD11918E> /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
    0x7fff923f0000 -     0x7fff924defff  libJP2.dylib (1044) <BE5FF765-5ECE-38B5-BF5D-BE806F5CAD18> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJP2.dylib
    0x7fff924df000 -     0x7fff92503ff7  libJPEG.dylib (1044) <BE0ED4E1-F7FC-3038-86D3-0456DD173FCB> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libJPEG.dylib
    0x7fff92504000 -     0x7fff92577fff  com.apple.securityfoundation (6.0 - 55122.3) <0FDC8F53-104C-3938-A852-5B33C30BAAD5> /System/Library/Frameworks/SecurityFoundation.framework/Versions/A/SecurityFoundation
    0x7fff92578000 -     0x7fff92608ff7  com.apple.Metadata (10.7.0 - 800.28) <E85AEB1B-CB17-38BC-B5C6-AAB50B47AF05> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/Metadata.framework/Versions/A/Metadata
    0x7fff9260b000 -     0x7fff92619fff  com.apple.opengl (9.6.1 - 9.6.1) <B22FA400-5824-36AF-9945-5FEC31995A0E> /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL
    0x7fff9261a000 -     0x7fff92661fff  libFontRegistry.dylib (127) <A77A0480-AA5D-3CC8-8B68-69985CD546DC> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontRegistry.dylib
    0x7fff92662000 -     0x7fff92664ffb  libutil.dylib (34) <DAC4A6CF-A1BB-3874-9569-A919316D30E8> /usr/lib/libutil.dylib
    0x7fff92665000 -     0x7fff92666fff  libsystem_sandbox.dylib (278.11.1) <0D0B13EA-6B7A-3AC8-BE60-B548543BEB77> /usr/lib/system/libsystem_sandbox.dylib
    0x7fff926d6000 -     0x7fff926ddffb  libcopyfile.dylib (103.92.1) <CF29DFF6-0589-3590-834C-82E2316612E8> /usr/lib/system/libcopyfile.dylib
    0x7fff9270b000 -     0x7fff92723ff7  com.apple.openscripting (1.4 - 157) <B3B037D7-1019-31E6-9D17-08E699AF3701> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/OpenScripting.framework/Versions/A/OpenScripting
    0x7fff92747000 -     0x7fff9274ffff  libsystem_dnssd.dylib (522.92.1) <17B03FFD-92C5-3282-9981-EBB28B456207> /usr/lib/system/libsystem_dnssd.dylib
    0x7fff92750000 -     0x7fff9276bff7  libCRFSuite.dylib (34) <FFAE75FA-C54E-398B-AA97-18164CD9789D> /usr/lib/libCRFSuite.dylib
    0x7fff927ab000 -     0x7fff92911fff  libGLProgrammability.dylib (9.6.1) <07700B99-8542-32D7-BB96-29472EFE75EF> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLProgrammability.dylib
    0x7fff92c73000 -     0x7fff92c78fff  com.apple.DiskArbitration (2.6 - 2.6) <A4165553-770E-3D27-B217-01FC1F852B87> /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
    0x7fff92c79000 -     0x7fff937efff7  com.apple.AppKit (6.9 - 1265.21) <9DC13B27-841D-3839-93B2-3EDE66157BDE> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
    0x7fff937f0000 -     0x7fff937f2ff7  com.apple.securityhi (9.0 - 55005) <18C42525-688C-3D47-B9C9-1E0F8F58FA64> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/SecurityHI.framework/Versions/A/SecurityHI
    0x7fff93845000 -     0x7fff93886fff  com.apple.PerformanceAnalysis (1.47 - 47) <7B73DFF4-75DB-3403-80D2-0F3FE48764C3> /System/Library/PrivateFrameworks/PerformanceAnalysis.framework/Versions/A/PerformanceAnalysis
    0x7fff93906000 -     0x7fff93bf0fff  com.apple.CoreServices.CarbonCore (1077.17 - 1077.17) <3A2E92FD-DEE2-3D45-9619-11500801A61C> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/CarbonCore
    0x7fff93bf1000 -     0x7fff93bf5ff7  libcache.dylib (62) <BDC1E65B-72A1-3DA3-A57C-B23159CAAD0B> /usr/lib/system/libcache.dylib
    0x7fff93f12000 -     0x7fff93f23ff7  libsystem_asl.dylib (217.1.4) <655FB343-52CF-3E2F-B14D-BEBF5AAEF94D> /usr/lib/system/libsystem_asl.dylib
    0x7fff93f24000 -     0x7fff93f2eff7  com.apple.CrashReporterSupport (10.9 - 539) <B25A09EC-A021-32EC-86F8-05B4837E0EDE> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/Versions/A/CrashReporterSupport
    0x7fff93f2f000 -     0x7fff93ff3ff7  com.apple.backup.framework (1.5.4 - 1.5.4) <195DA868-47A5-37E6-8CF0-9BCF11846899> /System/Library/PrivateFrameworks/Backup.framework/Versions/A/Backup
    0x7fff93ff4000 -     0x7fff9418fff8  com.apple.CFNetwork (673.3 - 673.3) <4375B7CB-34B6-3A26-99AC-2D2404AD9C9B> /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork
    0x7fff94190000 -     0x7fff94207fff  com.apple.CoreServices.OSServices (600.4 - 600.4) <C63562F5-6DF5-3EE9-8897-FF61A44C8251> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/OSServices.framework/Versions/A/OSServices
    0x7fff9420e000 -     0x7fff9422aff7  libsystem_kernel.dylib (2422.115.4) <9EDE872E-2A9E-3A78-8E1D-AB790794A098> /usr/lib/system/libsystem_kernel.dylib
    0x7fff94245000 -     0x7fff94247ff3  libsystem_configuration.dylib (596.15) <4998CB6A-9D54-390A-9F57-5D1AC53C135C> /usr/lib/system/libsystem_configuration.dylib
    0x7fff94248000 -     0x7fff942aefff  com.apple.framework.CoreWiFi (2.0 - 200.21.1) <5491896D-78C5-30B6-96E9-D8DDECF3BE73> /System/Library/Frameworks/CoreWiFi.framework/Versions/A/CoreWiFi
    0x7fff942af000 -     0x7fff942b8ffd  com.apple.CommonAuth (4.0 - 2.0) <32BA436F-6319-3A0B-B5D2-2EB75FF36B5B> /System/Library/PrivateFrameworks/CommonAuth.framework/Versions/A/CommonAuth
    0x7fff942b9000 -     0x7fff9439dff7  com.apple.coreui (2.2 - 231.1) <187DF89C-8A64-366D-8782-F90315FA3CD7> /System/Library/PrivateFrameworks/CoreUI.framework/Versions/A/CoreUI
    0x7fff9439e000 -     0x7fff943b5ff7  com.apple.CFOpenDirectory (10.9 - 173.90.1) <7BC0194E-1B40-3FCA-ACD2-235CE5D65DFA> /System/Library/Frameworks/OpenDirectory.framework/Versions/A/Frameworks/CFOpenDirectory.framework/Versions/A/CFOpenDirectory
    0x7fff9441e000 -     0x7fff9448bfff  com.apple.SearchKit (1.4.0 - 1.4.0) <B9B8D510-A27E-36B0-93E9-17146D9E9045> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/SearchKit.framework/Versions/A/SearchKit
    0x7fff944df000 -     0x7fff944e7ffc  libGFXShared.dylib (9.6.1) <25BBF325-AC57-3BAA-9427-2D14CC243AE6> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGFXShared.dylib
    0x7fff944e8000 -     0x7fff945d9ff9  libiconv.2.dylib (41) <BB44B115-AC32-3877-A0ED-AEC6232A4563> /usr/lib/libiconv.2.dylib
    0x7fff94619000 -     0x7fff9461afff  liblangid.dylib (117) <9546E641-F730-3AB0-B3CD-E0E2FDD173D9> /usr/lib/liblangid.dylib
    0x7fff94a1e000 -     0x7fff94b0dfff  libFontParser.dylib (111.1) <835A8253-6AB9-3AAB-9CBF-171440DEC486> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ATS.framework/Versions/A/Resources/libFontParser.dylib
    0x7fff94b3e000 -     0x7fff94c08ff7  com.apple.LaunchServices (572.28 - 572.28) <FC72C089-A069-3374-B80A-E041AF149F24> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/LaunchServices
    0x7fff94c21000 -     0x7fff94eb5ff7  com.apple.RawCamera.bundle (5.07 - 760) <EA94F148-975D-32D7-8A20-B06017E5793B> /System/Library/CoreServices/RawCamera.bundle/Contents/MacOS/RawCamera
    0x7fff94eb6000 -     0x7fff94ebafff  libpam.2.dylib (20) <B93CE8F5-DAA8-30A1-B1F6-F890509513CB> /usr/lib/libpam.2.dylib
    0x7fff94f71000 -     0x7fff94f7eff7  libxar.1.dylib (202) <5572AA71-E98D-3FE1-9402-BB4A84E0E71E> /usr/lib/libxar.1.dylib
    0x7fff9518a000 -     0x7fff95195fff  libkxld.dylib (2422.115.4) <3C678B75-F7C5-3DBB-8DBD-48483AD54D5C> /usr/lib/system/libkxld.dylib
    0x7fff95582000 -     0x7fff955aaffb  libxslt.1.dylib (13) <C9794936-633C-3F0C-9E71-30190B9B41C1> /usr/lib/libxslt.1.dylib
    0x7fff955ab000 -     0x7fff955b1ff7  libsystem_platform.dylib (24.90.1) <3C3D3DA8-32B9-3243-98EC-D89B9A1670B3> /usr/lib/system/libsystem_platform.dylib
    0x7fff955b2000 -     0x7fff95706ff3  com.apple.audio.toolbox.AudioToolbox (1.10 - 1.10) <69B273E8-5A8E-3FC7-B807-C16B657662FE> /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
    0x7fff9573c000 -     0x7fff9576cfff  com.apple.IconServices (25 - 25.17) <4751127E-FBD5-3ED5-8510-08D4E4166EFE> /System/Library/PrivateFrameworks/IconServices.framework/Versions/A/IconServices
    0x7fff958b4000 -     0x7fff958bcff3  libCGCMS.A.dylib (599.35.4) <67AD122A-B8DA-3C05-8B8C-1939F5064FAE> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGCMS.A.dylib
    0x7fff958bd000 -     0x7fff958d8ff7  libsystem_malloc.dylib (23.10.1) <A695B4E4-38E9-332E-A772-29D31E3F1385> /usr/lib/system/libsystem_malloc.dylib
    0x7fff958d9000 -     0x7fff95d0cffb  com.apple.vision.FaceCore (3.0.0 - 3.0.0) <F42BFC9C-0B16-35EF-9A07-91B7FDAB7FC5> /System/Library/PrivateFrameworks/FaceCore.framework/Versions/A/FaceCore
    0x7fff95d0d000 -     0x7fff95f71ffd  com.apple.security (7.0 - 55471.14.18) <83A9E8C8-06A1-3F6D-8514-C35CD0DBD370> /System/Library/Frameworks/Security.framework/Versions/A/Security
    0x7fff95f72000 -     0x7fff95f75fff  com.apple.help (1.3.3 - 46) <AE763646-D07A-3F9A-ACD4-F5CBD734EE36> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Help.framework/Versions/A/Help
    0x7fff95f8f000 -     0x7fff95f98fff  com.apple.speech.synthesis.framework (4.7.1 - 4.7.1) <383FB557-E88E-3239-82B8-15F9F885B702> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/SpeechSynthesis.framework/Versions/A/SpeechSynthesis
    0x7fff95f99000 -     0x7fff9617efff  com.apple.CoreFoundation (6.9 - 855.17) <729BD6DA-1F63-3E72-A148-26F21EBF52BB> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7fff96298000 -     0x7fff96324ff7  com.apple.ink.framework (10.9 - 207) <8A50B893-AD03-3826-8555-A54FEAF08F47> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
    0x7fff96325000 -     0x7fff96372ff2  com.apple.print.framework.PrintCore (9.0 - 428) <8D8253E3-302F-3DB2-9C5C-572CB974E8B3> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Versions/A/PrintCore
    0x7fff96379000 -     0x7fff96379ffd  com.apple.audio.units.AudioUnit (1.10 - 1.10) <68B21135-55A6-3563-A3D6-3E692A7DEB7F> /System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit
    0x7fff963dc000 -     0x7fff96465fff  com.apple.ColorSync (4.9.0 - 4.9.0) <B756B908-9AD1-3F5D-83F9-7A0B068387D2> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ColorSync.framework/Versions/A/ColorSync
    0x7fff96495000 -     0x7fff96495ff7  libkeymgr.dylib (28) <3AA8D85D-CF00-3BD3-A5A0-E28E1A32A6D8> /usr/lib/system/libkeymgr.dylib
    0x7fff96496000 -     0x7fff96632ff3  com.apple.QuartzCore (1.8 - 332.3) <72003E51-1287-395B-BCBC-331597D45C5E> /System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore
    0x7fff9663c000 -     0x7fff966a1ffb  com.apple.Heimdal (4.0 - 2.0) <F34D6627-9F80-3823-8B57-DB629307DF87> /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal
    0x7fff966a2000 -     0x7fff966a6fff  com.apple.CommonPanels (1.2.6 - 96) <6B434AFD-50F8-37C7-9A56-162C17E375B3> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/CommonPanels.framework/Versions/A/CommonPanels
    0x7fff966a7000 -     0x7fff966d1ff7  libpcap.A.dylib (42) <91D3FF51-D6FE-3C05-98C9-1182E0EC3D58> /usr/lib/libpcap.A.dylib
    0x7fff9672a000 -     0x7fff96743ff7  com.apple.Ubiquity (1.3 - 289) <C7F1B734-CE81-334D-BE41-8B20D95A1F9B> /System/Library/PrivateFrameworks/Ubiquity.framework/Versions/A/Ubiquity
    0x7fff968c0000 -     0x7fff968c0fff  com.apple.Carbon (154 - 157) <45A9A40A-78FF-3EA0-8FAB-A4F81052FA55> /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
    0x7fff969b6000 -     0x7fff96a11ffb  com.apple.AE (665.5 - 665.5) <BBA230F9-144C-3CAB-A77A-0621719244CD> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/AE.framework/Versions/A/AE
    0x7fff96a65000 -     0x7fff96a7ffff  libdispatch.dylib (339.92.1) <C4E4A18D-3C3B-3C9C-8709-A4270D998DE7> /usr/lib/system/libdispatch.dylib
    0x7fff96f08000 -     0x7fff96f0aff7  libquarantine.dylib (71) <7A1A2BCB-C03D-3A25-BFA4-3E569B2D2C38> /usr/lib/system/libquarantine.dylib
    0x7fff96f18000 -     0x7fff96f1bfff  com.apple.TCC (1.0 - 1) <32A075D9-47FD-3E71-95BC-BFB0D583F41C> /System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC
    0x7fff96f1c000 -     0x7fff96f1dff7  libSystem.B.dylib (1197.1.1) <E303F2F8-A8CF-3DF3-84B3-F2D0EE41CCF6> /usr/lib/libSystem.B.dylib
    0x7fff96f21000 -     0x7fff96f2cff7  com.apple.NetAuth (5.0 - 5.0) <C811E662-9EC3-3B74-808A-A75D624F326B> /System/Library/PrivateFrameworks/NetAuth.framework/Versions/A/NetAuth
    0x7fff96f2d000 -     0x7fff96f45ff7  com.apple.GenerationalStorage (2.0 - 160.3) <64749B08-0212-3AC8-9B49-73D662B09304> /System/Library/PrivateFrameworks/GenerationalStorage.framework/Versions/A/GenerationalStorage
    0x7fff96f49000 -     0x7fff96f5bfff  com.apple.ImageCapture (9.0 - 9.0) <BE0B65DA-3031-359B-8BBA-B9803D4ADBF4> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/ImageCapture.framework/Versions/A/ImageCapture
    0x7fff96f83000 -     0x7fff96f89fff  com.apple.AOSNotification (1.7.0 - 760.3) <7901B867-60F7-3645-BB3E-18C51A6FBCC6> /System/Library/PrivateFrameworks/AOSNotification.framework/Versions/A/AOSNotification
    0x7fff96f8d000 -     0x7fff96fd2ff6  com.apple.HIServices (1.23 - 468) <5970AF5C-F5BD-3B6A-97C9-95B2CA98D71D> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/HIServices
    0x7fff96fd3000 -     0x7fff96fd7fff  com.apple.IOAccelerator (98.23 - 98.23) <A5174BEC-A27D-34D8-AB7B-B86962FFAEBA> /System/Library/PrivateFrameworks/IOAccelerator.framework/Versions/A/IOAccelerator
    0x7fff96fd8000 -     0x7fff96fddfff  libmacho.dylib (845) <1D2910DF-C036-3A82-A3FD-44FF73B5FF9B> /usr/lib/system/libmacho.dylib
    0x7fff97032000 -     0x7fff97059ffb  libsystem_info.dylib (449.1.3) <7D41A156-D285-3849-A2C3-C04ADE797D98> /usr/lib/system/libsystem_info.dylib
    0x7fff97097000 -     0x7fff970f0fff  libTIFF.dylib (1044) <FBC5800B-7F34-3755-A44E-7B37B3E0B32E> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libTIFF.dylib
    0x7fff970f1000 -     0x7fff97133ff7  libauto.dylib (185.5) <F45C36E8-B606-3886-B5B1-B6745E757CA8> /usr/lib/libauto.dylib
    0x7fff9713f000 -     0x7fff9715aff7  libPng.dylib (1044) <151BA92C-6E7C-3B69-8024-FDD1E2C89DD3> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libPng.dylib
    0x7fff97179000 -     0x7fff9719eff7  com.apple.ChunkingLibrary (2.0 - 155.1) <B845DC7A-D1EA-31E2-967C-D1FE0C628036> /System/Library/PrivateFrameworks/ChunkingLibrary.framework/Versions/A/ChunkingLibrary
    0x7fff9719f000 -     0x7fff971defff  libGLU.dylib (9.6.1) <AE032555-3E2F-3DBF-A26D-EA4576061605> /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGLU.dylib
    0x7fff971df000 -     0x7fff97214ffc  com.apple.LDAPFramework (2.4.28 - 194.5) <4ADD0595-25B9-3F09-897E-3FB790AD2C5A> /System/Library/Frameworks/LDAP.framework/Versions/A/LDAP
    0x7fff97215000 -     0x7fff97221ffb  com.apple.AppleFSCompression (56.92.1 - 1.0) <066255FD-DBD1-3041-8DDA-7AFC41C9096D> /System/Library/PrivateFrameworks/AppleFSCompression.framework/Versions/A/AppleFSCompression
    0x7fff9744a000 -     0x7fff974d3ff7  libsystem_c.dylib (997.90.3) <6FD3A400-4BB2-3B95-B90C-BE6E9D0D78FA> /usr/lib/system/libsystem_c.dylib
    0x7fff974d4000 -     0x7fff974d5fff  com.apple.TrustEvaluationAgent (2.0 - 25) <334A82F4-4AE4-3719-A511-86D0B0723E2B> /System/Library/PrivateFrameworks/TrustEvaluationAgent.framework/Versions/A/TrustEvaluationAgent
    0x7fff974d6000 -     0x7fff97557fff  com.apple.CoreSymbolication (3.0.1 - 141.0.5) <20E484C4-9F0E-3DF6-BB27-D509859FF57A> /System/Library/PrivateFrameworks/CoreSymbolication.framework/Versions/A/CoreSymbolication
    0x7fff97558000 -     0x7fff97562ff7  libcsfde.dylib (380.70.2) <3ACB87D7-A81C-3C45-B648-AD27F1B9D841> /usr/lib/libcsfde.dylib
    0x7fff97880000 -     0x7fff97b80ff7  com.apple.Foundation (6.9 - 1056.16) <24349208-3603-3F5D-95CC-B379616FBEF8> /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
    0x7fff97b81000 -     0x7fff97bbaff7  com.apple.QD (3.50 - 298) <C1F20764-DEF0-34CF-B3AB-AB5480D64E66> /System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/QD.framework/Versions/A/QD
    0x7fff97bbb000 -     0x7fff97c6bff7  libvMisc.dylib (423.32) <049C0735-1808-39B9-943F-76CB8021744F> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvMisc.dylib
    0x7fff97da1000 -     0x7fff97df3fff  libc++.1.dylib (120) <4F68DFC5-2077-39A8-A449-CAC5FDEE7BDE> /usr/lib/libc++.1.dylib
    0x7fff97df4000 -     0x7fff97e47fff  com.apple.ScalableUserInterface (1.0 - 1) <CF745298-7373-38D2-B3B1-727D5A569E48> /System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/ScalableUserInterface.framework/Versions/A/ScalableUserInterface
    0x7fff97ea7000 -     0x7fff98054f27  libobjc.A.dylib (551.1) <AD7FD984-271E-30F4-A361-6B20319EC73B> /usr/lib/libobjc.A.dylib
    0x7fff98055000 -     0x7fff98062ff0  libbz2.1.0.dylib (29) <0B98AC35-B138-349C-8063-2B987A75D24C> /usr/lib/libbz2.1.0.dylib
    0x7fff98272000 -     0x7fff98275ffa  libCGXType.A.dylib (599.35.4) <A2B493FD-2EDE-3BC2-A281-2381E0156411> /System/Library/Frameworks/CoreGraphics.framework/Versions/A/Resources/libCGXType.A.dylib
    0x7fff98724000 -     0x7fff98729ff7  libunwind.dylib (35.3) <78DCC358-2FC1-302E-B395-0155B47CB547> /usr/lib/system/libunwind.dylib
    0x7fff98734000 -     0x7fff98734fff  com.apple.Accelerate.vecLib (3.9 - vecLib 3.9) <F8D0CC77-98AC-3B58-9FE6-0C25421827B6> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/vecLib
    0x7fff98735000 -     0x7fff98739ff7  libGIF.dylib (1044) <7E51DFC3-740A-3CD3-98A1-1EC510A4A055> /System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib
    0x7fff9873a000 -     0x7fff98a0bff4  com.apple.CoreImage (9.4.0) <2C636ECD-0F1A-357C-9EFF-0452476FDDF5> /System/Library/Frameworks/QuartzCore.framework/Versions/A/Frameworks/CoreImage.framework/Versions/A/CoreImage
    0x7fff98a3d000 -     0x7fff98a8eff7  com.apple.audio.CoreAudio (4.2.1 - 4.2.1) <BE13E840-FB45-3BC2-BCF5-031629754FD5> /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
    0x7fff98ab3000 -     0x7fff98b6bff7  com.apple.DiscRecording (8.0 - 8000.4.6) <CDAAAD04-A1D0-3C67-ABCC-EFC9E8D44E7E> /System/Library/Frameworks/DiscRecording.framework/Versions/A/DiscRecording
    0x7fff98b6e000 -     0x7fff98b97ff7  libc++abi.dylib (49.1) <21A807D3-6732-3455-B77F-743E9F916DF0> /usr/lib/libc++abi.dylib
    0x7fff98d8a000 -     0x7fff9905efc7  com.apple.vImage (7.0 - 7.0) <D241DBFA-AC49-31E2-893D-EAAC31890C90> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vImage.framework/Versions/A/vImage
    0x7fff9905f000 -     0x7fff9905ffff  com.apple.Accelerate (1.9 - Accelerate 1.9) <509BB27A-AE62-366D-86D8-0B06D217CF56> /System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate
    0x7fff9910a000 -     0x7fff992aaff7  GLEngine (9.6.1) <28300FBD-E3B2-35D2-BB54-77DCE62FC371> /System/Library/Frameworks/OpenGL.framework/Versions/A/Resources/GLEngine.bundle/GLEngine
    0x7fff993a8000 -     0x7fff99479ff1  com.apple.DiskImagesFramework (10.9 - 371.1) <DCCAADEC-35D5-3968-8B39-358ACC56ADC4> /System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/DiskImages
    0x7fff9947a000 -     0x7fff99483ff7  libcldcpuengine.dylib (2.3.58) <E3A84FEC-4060-39C2-A469-159A443D2B6D> /System/Library/Frameworks/OpenCL.framework/Versions/A/Libraries/libcldcpuengine.dylib
    0x7fff99484000 -     0x7fff99485ff7  com.apple.print.framework.Print (9.0 - 260) <EE00FAE1-DA03-3EC2-8571-562518C46994> /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Print.framework/Versions/A/Print
    0x7fff99488000 -     0x7fff99495ff4  com.apple.Librarian (1.2 - 1) <F1A2744D-8536-32C7-8218-9972C6300DAE> /System/Library/PrivateFrameworks/Librarian.framework/Versions/A/Librarian
    0x7fff99496000 -     0x7fff9959cff7  com.apple.ImageIO.framework (3.3.0 - 1044) <3BCCF2AE-CF1F-3324-A371-DF0A42C841A2> /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
    0x7fff995bc000 -     0x7fff995c3ff7  libsystem_pthread.dylib (53.1.4) <AB498556-B555-310E-9041-F67EC9E00E2C> /usr/lib/system/libsystem_pthread.dylib
    0x7fff995c4000 -     0x7fff995c5ff7  libDiagnosticMessagesClient.dylib (100) <4CDB0F7B-C0AF-3424-BC39-495696F0DB1E> /usr/lib/libDiagnosticMessagesClient.dylib
    0x7fff995c6000 -     0x7fff99691fff  libvDSP.dylib (423.32) <3BF732BE-DDE0-38EB-8C54-E4E3C64F77A7> /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libvDSP.dylib
    0x7fff99771000 -     0x7fff9984dfff  libcrypto.0.9.8.dylib (52) <ED7F3865-10D4-346B-8C9C-D968EB3B5D35> /usr/lib/libcrypto.0.9.8.dylib
    0x7fff9984e000 -     0x7fff998a6ff7  com.apple.Symbolication (1.4 - 129.0.2) <B1F008C4-184D-36A2-922F-4A67A075D512> /System/Library/PrivateFrameworks/Symbolication.framework/Versions/A/Symbolication
    0x7fff998a7000 -     0x7fff998b1ff7  com.apple.bsd.ServiceManagement (2.0 - 2.0) <2D27B498-BB9C-3D88-B05A-76908A8A26F3> /System/Library/Frameworks/ServiceManagement.framework/Versions/A/ServiceManagement
    0x7fff998b2000 -     0x7fff9993dff7  libCoreStorage.dylib (380.70.2) <BD993BC8-ED54-3DC1-B28B-3B6AC77E8E5C> /usr/lib/libCoreStorage.dylib
    0x7fff9993e000 -     0x7fff99962fff  libxpc.dylib (300.90.2) <AB40CD57-F454-3FD4-B415-63B3C0D5C624> /usr/lib/system/libxpc.dylib
    0x7fff99963000 -     0x7fff9996afff  com.apple.NetFS (6.0 - 4.0) <8E26C099-CE9D-3819-91A2-64EA929C6137> /System/Library/Frameworks/NetFS.framework/Versions/A/NetFS
    0x7fff99c08000 -     0x7fff99c31fff  com.apple.DictionaryServices (1.2 - 208) <A539A058-BA57-35EE-AA08-D0B0E835127D> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/DictionaryServices.framework/Versions/A/DictionaryServices

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 1
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 279317
    thread_create: 1
    thread_set_state: 27078

VM Region Summary:
ReadOnly portion of Libraries: Total=308.7M resident=113.3M(37%) swapped_out_or_unallocated=195.4M(63%)
Writable regions: Total=2.4G written=208.3M(8%) resident=242.5M(10%) swapped_out=496K(0%) unallocated=2.2G(90%)

REGION TYPE                        VIRTUAL
===========                        =======
ATS (font support)                   32.0M
ATS (font support) (reserved)           8K        reserved VM address space (unallocated)
CG backing stores                    4760K
CG image                               12K
CG raster data                         24K
CG shared images                      244K
CoreImage                               8K
Dispatch continuations               16.0M
IOKit                                22.4M
IOKit (reserved)                        4K        reserved VM address space (unallocated)
JS JIT generated code               128.1M
JS JIT generated code (reserved)      1.9G        reserved VM address space (unallocated)
JS VM register file                  24.0M
JS garbage collector                 3456K
Kernel Alloc Once                       8K
MALLOC                              304.6M
MALLOC (admin)                         32K
Memory Tag 242                         12K
Memory Tag 251                          8K
OpenCL                                 24K
OpenGL GLSL                          1664K
STACK GUARD                          56.1M
Stack                                17.3M
VM_ALLOCATE                          25.7M
WebKit Malloc                        1184K
__DATA                               45.3M
__IMAGE                               528K
__LINKEDIT                           93.7M
__TEXT                              215.0M
__UNICODE                             544K
mapped file                          63.3M
shared memory                          68K
===========                        =======
TOTAL                                 2.9G
TOTAL, minus reserved VM space        1.0G


Model: MacBookPro9,1, BootROM MBP91.00D3.B08, 4 processors, Intel Core i7, 2.6 GHz, 8 GB, SMC 2.1f175
Graphics: Intel HD Graphics 4000, Intel HD Graphics 4000, Built-In
Graphics: NVIDIA GeForce GT 650M, NVIDIA GeForce GT 650M, PCIe, 1024 MB
Memory Module: BANK 0/DIMM0, 4 GB, DDR3, 1600 MHz, 0x02FE, 0x45424A3431554638424455302D474E2D4620
Memory Module: BANK 1/DIMM0, 4 GB, DDR3, 1600 MHz, 0x02FE, 0x45424A3431554638424455302D474E2D4620
AirPort: spairport_wireless_card_type_airport_extreme (0x14E4, 0xF5), Broadcom BCM43xx 1.0 (5.106.98.100.22)
Bluetooth: Version 4.2.7f3 14616, 3 services, 23 devices, 1 incoming serial ports
Network Service: Wi-Fi, AirPort, en1
Serial ATA Device: APPLE HDD HTS727575A9E362, 750.16 GB
Serial ATA Device: MATSHITADVD-R   UJ-8A8
USB Device: Hub
USB Device: FaceTime HD Camera (Built-in)
USB Device: Hub
USB Device: Hub
USB Device: Apple Internal Keyboard / Trackpad
USB Device: IR Receiver
USB Device: BRCM20702 Hub
USB Device: Bluetooth USB Host Controller
USB Device: PX4 FMU v2.x
Thunderbolt Bus: MacBook Pro, Apple Inc., 25.1
```
