### PR TITLE
Build: Fixes for compiling for (RedHat-style) Linux, removed reference t...

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -449,8 +449,7 @@ MacBuild {
 
 LinuxBuild {
 	LIBS += \
-        -lSDL2 \
-        -lSDL2main
+        -lSDL2
 }
 
 WindowsBuild {


### PR DESCRIPTION
...o SDL2main lib

Explicit linking against SDL2main breaks the build on RedHat/Fedora-style Linux distributions, and seems to be redundant on Ubuntu etc.
