### PR TITLE
Comm: reset base_mode, custom_mode & status on connection lost

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -266,9 +266,6 @@ void UAS::updateState()
     {
         connectionLost = true;
         receivedMode = false;
-        base_mode = -1;
-        custom_mode = -1;
-        status = -1;
         QString audiostring = QString("Link lost to system %1").arg(this->getUASID());
         GAudioOutput::instance()->say(audiostring.toLower());
     }
@@ -486,6 +483,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
                 shortStateText = uasState;
             }
 
+            receivedMode = true;
             if (base_mode != state.base_mode) {
                 QLOG_DEBUG() << "UAS: new base mode " << state.base_mode;
                 modeHasChanged = true;


### PR DESCRIPTION
If the link with the UAS is lost, receivedMode is turned to false. Yet when the link is regained and the HEARTBEAT message is received (with the same base_mode) receivedMode will stay false and prevent UAS::setMode() from sending mode update to the UAS.

I am not sure this PR is the correct or best one, but it does address the issue.
