### PR TITLE
Joystick: Ensure changes in Widget are picked up

### DIFF
--- a/src/input/JoystickInput.h
+++ b/src/input/JoystickInput.h
@@ -126,15 +126,15 @@ protected:
     QAtomicInt done;
 
     // Axis 3 is thrust (CALIBRATION!)
-    int thrustAxis;
-    int xAxis;
-    int yAxis;
-    int yawAxis;
-    bool thrustReversed;
-    bool xReversed;
-    bool yReversed;
-    bool yawReversed;
-    int autoButtonMapping;
+    volatile int thrustAxis;
+    volatile int xAxis;
+    volatile int yAxis;
+    volatile int yawAxis;
+    volatile bool thrustReversed;
+    volatile bool xReversed;
+    volatile bool yReversed;
+    volatile bool yawReversed;
+    volatile int autoButtonMapping;
     int stabilizeButtonMapping;
     int thrustValue;
     int xValue;


### PR DESCRIPTION
make state variables shared between JoystickInput and JoystickWidget (on different threads) volatile so changes in the UI are actually picked up by JoystickInput
