### PR TITLE
Joystick: make sure base_mode has been received from UAS before testing it

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -2859,7 +2859,8 @@ void UAS::setManualControlCommands(double roll, double pitch, double yaw, double
     Q_UNUSED(xHat);
     Q_UNUSED(yHat);
 
-    if(! (base_mode & MAV_MODE_FLAG_DECODE_POSITION_SAFETY))
+    if(! receivedMode
+        || ! (base_mode & MAV_MODE_FLAG_DECODE_POSITION_SAFETY))
     {
 //        QLOG_TRACE() << "JOYSTICK/MANUAL CONTROL: IGNORING COMMANDS: Not armed";
         manualControl = false;


### PR DESCRIPTION
base_mode is defaulted to -1, so ensure base_mode was actually received from the UAS before testing it.
