### PR TITLE
Add dependancy on qtdeclarative5-qtquick2-plugin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.4
 
 Package: apmplanner2
 Architecture: any
-Depends: ${shlibs:Depends}
+Depends: ${shlibs:Depends}, qtdeclarative5-qtquick2-plugin
 Description: Ground station software for autonomous vehicles.
  A GUI ground control station for autonomous vehicles 
  using the MAVLink protocol.


### PR DESCRIPTION
Shlibs won't find qtquick2, as it is a plugin into qt rather than a shared library. 
Fixes diydrones/apm_planner#532
