### PR TITLE
Build: Removed link to libSDL2main.a for Linux build

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -449,8 +449,7 @@ MacBuild {
 
 LinuxBuild {
 	LIBS += \
-        -lSDL2 \
-        -lSDL2main
+        -lSDL2 
 }
 
 WindowsBuild {


### PR DESCRIPTION
as this file is not shipped with some Linux distributions (e.g. Arch) and it should not be needed anyway when building for Linux only.
