### PR TITLE
Comm: Fixed ambiguous cast that breaks compile.

### DIFF
--- a/src/comm/MAVLinkDecoder.cc
+++ b/src/comm/MAVLinkDecoder.cc
@@ -586,7 +586,7 @@ QPair<QString,QVariant> MAVLinkDecoder::emitFieldValue(mavlink_message_t* msg, i
         else
         {
             // Single value
-            uint64_t n = *((uint64_t*)(m+messageInfo[msgid].fields[fieldid].wire_offset));
+            qulonglong n = *((uint64_t*)(m+messageInfo[msgid].fields[fieldid].wire_offset));
             fieldType = "uint64_t";
             if (localemit)
             {
@@ -619,7 +619,7 @@ QPair<QString,QVariant> MAVLinkDecoder::emitFieldValue(mavlink_message_t* msg, i
         else
         {
             // Single value
-            int64_t n = *((int64_t*)(m+messageInfo[msgid].fields[fieldid].wire_offset));
+            qulonglong n = *((int64_t*)(m+messageInfo[msgid].fields[fieldid].wire_offset));
             fieldType = "int64_t";
             if (localemit)
             {


### PR DESCRIPTION
I tried to update apm_planner but I had issues compling from source.  This is how I fixed the error that is below:

```
src/comm/MAVLinkDecoder.cc: In member function ‘QPair<QString, QVariant> MAVLinkDecoder::emitFieldValue(mavlink_message_t*, int, quint64)’:
src/comm/MAVLinkDecoder.cc:599:27: error: conversion from ‘uint64_t {aka long unsigned int}’ to ‘const QVariant’ is ambiguous
             retval.second = n;
```

I am using Ubuntu 14.04 which is up to date.
