### PR TITLE
Comm: EXC_BAD_ACCESS in TCPLink

### DIFF
--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -151,6 +151,9 @@ void TCPLink::_writeDebugBytes(const char *data, qint16 size)
 
 void TCPLink::writeBytes(const char* data, qint64 size)
 {
+    if (! _socketIsConnected)
+        return;
+
 #ifdef TCPLINK_READWRITE_DEBUG
     _writeDebugBytes(data, size);
 #endif
@@ -256,11 +259,14 @@ bool TCPLink::connect()
 
 void TCPLink::newConnection()
 {
-    qDebug() << _name << ": new connection";
-
-    Q_ASSERT(_socket == NULL);
+    if (_socket != NULL)
+        disconnect();
 
     _socket = _server.nextPendingConnection();
+    if (_socket == NULL)
+        return;
+
+    qDebug() << _name << ": new connection";
 
     QObject::connect(_socket, SIGNAL(readyRead()), this, SLOT(readBytes()));
     QObject::connect(_socket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(_socketError(QAbstractSocket::SocketError)));

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -61,7 +61,6 @@ public:
     QHostAddress getHostAddress(void) const { return _hostAddress; }
     quint16 getPort(void) const { return _port; }
     bool isServer(void) const { return _asServer; }
-    QTcpSocket* getSocket(void) { return _socket; }
 
     // LinkInterface methods
     virtual int     getId(void) const;

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -3646,6 +3646,7 @@ void UAS::addLink(LinkInterface* link)
     {
         links->append(link);
         connect(link, SIGNAL(destroyed(QObject*)), this, SLOT(removeLink(QObject*)));
+        connect(link,SIGNAL(disconnected(QObject*)),this,SLOT(disconnected(QObject*)));
         connect(link,SIGNAL(disconnected()),this,SIGNAL(disconnected()));
         connect(link,SIGNAL(connected()),this,SIGNAL(connected()));
         if(link->isConnected())


### PR DESCRIPTION
Comm: Make sure link is disconnect from UAS so we don't try to send messages, heartbeat in particular, through a disconnected link.

Addresses the following EXC_BAD_ACCESS:

```
* thread #1: tid = 0x22d86, 0x000000010213d7da QtCore`QIODevice::write(char const*, long long) + 26, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x8)
    frame #0: 0x000000010213d7da QtCore`QIODevice::write(char const*, long long) + 26
QtCore`QIODevice::write(char const*, long long) + 26:
-> 0x10213d7da:  movq   0x8(%rbx), %r13
   0x10213d7de:  movl   0x70(%r13), %eax
   0x10213d7e2:  testb  $0x2, %al
   0x10213d7e4:  je     0x10213d8bb               ; QIODevice::write(char const*, long long) + 251
(lldb) bt
* thread #1: tid = 0x22d86, 0x000000010213d7da QtCore`QIODevice::write(char const*, long long) + 26, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x8)
  * frame #0: 0x000000010213d7da QtCore`QIODevice::write(char const*, long long) + 26
    frame #1: 0x0000000100313bd1 apmplanner2`TCPLink::writeBytes(this=0x000000011e1acaa0, data=0x00007fff5fbfc3c0, size=17) + 65 at TCPLink.cc:157
    frame #2: 0x000000010025b4f2 apmplanner2`UAS::sendMessage(this=0x00000001081d3a00, link=0x000000011e1acaa0, message=<unavailable>) + 354 at UAS.cc:2018
    frame #3: 0x0000000100259e63 apmplanner2`UAS::sendMessage(this=0x00000001081d3a00, message=<unavailable>) + 899 at UAS.cc:1944
    frame #4: 0x000000010025b777 apmplanner2`UAS::sendHeartbeat(this=0x00000001081d3a00) + 311 at UAS.cc:1993
```
