### PR TITLE
Reduced warnings emitted from Eigen

### DIFF
--- a/libs/eigen/Eigen/src/Core/util/DisableStupidWarnings.h
+++ b/libs/eigen/Eigen/src/Core/util/DisableStupidWarnings.h
@@ -37,6 +37,13 @@
     #pragma clang diagnostic push
   #endif
   #pragma clang diagnostic ignored "-Wconstant-logical-operand"
+#elif defined(__GNUC__) || defined(__GNUG__)
+  #ifndef EIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS
+    #pragma GCC diagnostic push
+  #endif
+  #pragma GCC diagnostic ignored "-Wenum-compare"
+  #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+  #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #endif
 
 #endif // not EIGEN_WARNINGS_DISABLED

--- a/libs/eigen/Eigen/src/Core/util/ReenableStupidWarnings.h
+++ b/libs/eigen/Eigen/src/Core/util/ReenableStupidWarnings.h
@@ -8,6 +8,8 @@
     #pragma warning pop
   #elif defined __clang__
     #pragma clang diagnostic pop
+  #elif defined(__GNUC__) || defined(__GNUG__)
+    #pragma GCC diagnostic pop
   #endif
 #endif
 

--- a/libs/eigen/Eigen/src/QR/HouseholderQR.h
+++ b/libs/eigen/Eigen/src/QR/HouseholderQR.h
@@ -245,7 +245,7 @@ void householder_qr_inplace_blocked(MatrixQR& mat, HCoeffs& hCoeffs,
 {
   typedef typename MatrixQR::Index Index;
   typedef typename MatrixQR::Scalar Scalar;
-  typedef typename MatrixQR::RealScalar RealScalar;
+  //typedef typename MatrixQR::RealScalar RealScalar;
   typedef Block<MatrixQR,Dynamic,Dynamic> BlockType;
 
   Index rows = mat.rows();


### PR DESCRIPTION
Hi all,
Compiling the APM-Planner on Linux (ubuntu 14.10) shows round about 2043 warnings. I dont 
think its really critical but we should do something about that cause nobody will pay any attention to warnings anymore nor will even recognise when producing them. 
In my opinion warning free compilation leads to better code quality and so should be a goal of development.
So I tried to do something to reduce warnings. The Eigen lib is the worst part as the programmer of the lib knows by himself he created an special include to supress warnings while his library is included. This special include does not provide the warning supression for the GCC. So I extended the precompiler code to support GCC too reducing the warnings to 1007 on my ubuntu.
Yes I know its not a good way to reduce warnings by supressing them, but it is an external lib and not maintained by the apm_planner people so the changes made to that code should be as small as possible.
Sure the way rolandbosa invented is the better one, he removed the eigen lib code completely, but unfortunately nobody was able to check his code for correctness.

Okay some details about the changes measured on Ubuntu 14.10, QTcreator 3.1.1, gcc 4.9.1
Changes of precompiler code -> reduces warnings from 2043 to 1007
removing the RealScalar type -> reduces warnings from 1007 to 880

greetings from Hamburg 