### PR TITLE
enable SiLabs USB support for 3DR Radio

### DIFF
--- a/src/ui/configuration/Radio3DRConfig.cc
+++ b/src/ui/configuration/Radio3DRConfig.cc
@@ -98,7 +98,7 @@ void Radio3DRConfig::fillPortsInfo(QComboBox &comboxBox)
              << (info.productIdentifier() ? QString::number(info.productIdentifier(), 16) : QString());
 
         int found = comboxBox.findData(list);
-        if ((found == -1)&& info.manufacturer().contains("FTDI")) {
+        if ((found == -1)&& (info.manufacturer().contains("FTDI") || info.manufacturer().contains("Silicon Labs"))) {
             QLOG_INFO() << "Inserting " << list.first();
             comboxBox.insertItem(0,list[0], list);
         } else {


### PR DESCRIPTION
Adding manufacturer "Silicon Labs" to enable SiLabs USB based 3DR Radio devices to be configured.