### PR TITLE
Comm: TCPLink doesn't update UI upon disconnection

### DIFF
--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -308,6 +308,7 @@ bool TCPLink::_hardwareConnect(void)
 
         QObject::connect(_socket, SIGNAL(readyRead()), this, SLOT(readBytes()));
         QObject::connect(_socket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(_socketError(QAbstractSocket::SocketError)));
+        QObject::connect(_socket, SIGNAL(disconnected()), this, SLOT(_socketDisconnected()));
 
         // Give the socket five seconds to connect to the other side otherwise error out
         if (!_socket->waitForConnected(5000))


### PR DESCRIPTION
Disconnecting a TCPLink leaves the UI in the "connected" state, and there is no way to reconnect.