### PR TITLE
Plan View: tooltip no longer adds MSL to any altitude.

### DIFF
--- a/libs/opmapcontrol/src/mapwidget/waypointitem.cpp
+++ b/libs/opmapcontrol/src/mapwidget/waypointitem.cpp
@@ -330,7 +330,7 @@ namespace mapcontrol
     void WayPointItem::RefreshToolTip()
     {
         QString coord_str = QString::number(coord.Lat(), 'f', 6) + "   " + QString::number(coord.Lng(), 'f', 6);
-        setToolTip(QString("WayPoint Number: %1\nDescription: %2\nCoordinate: %4\nAltitude: %5 m (MSL)\nHeading: %6 deg").arg(QString::number(WayPointItem::number)).arg(description).arg(coord_str).arg(QString::number(altitude)).arg(QString::number(heading)));
+        setToolTip(QString("WayPoint Number: %1\nDescription: %2\nCoordinate: %4\nAltitude: %5 m\nHeading: %6 deg").arg(QString::number(WayPointItem::number)).arg(description).arg(coord_str).arg(QString::number(altitude)).arg(QString::number(heading)));
     }
 
     int WayPointItem::snumber=0;


### PR DESCRIPTION
The WP tooltip said that any altitude were an MSL altitude, regardless
of the wp being relative to home_alt.
This could be dangerous if certain plan types were verified based on tooltip.
I tried to add conditional string, but did not find how to get altitude-type.