### PR TITLE
Audio: use "default" ALSA device instead of "plughw:0"

### DIFF
--- a/src/audio/AlsaAudio.cc
+++ b/src/audio/AlsaAudio.cc
@@ -178,7 +178,7 @@ bool AlsaAudio::alsa_play( QString filename )
 
 snd_pcm_t * AlsaAudio::alsa_open (int channels, int samplerate)
 {
-    const char * device = "plughw:0";
+    const char * device = "default";
     snd_pcm_t *alsa_dev;
     snd_pcm_hw_params_t *hw_params;
     snd_pcm_uframes_t buffer_size, xfer_align, start_threshold;


### PR DESCRIPTION
There is no reason to enforce playback via hardware device instead of the
default ALSA device configured in the system. Such a default device could be a
PulseAudio plugin for ALSA which allows ALSA clients to transparently use
PulseAudio - benefiting from its software mixing and preventing "Device or
resource busy" error when openning the audio device.