### PR TITLE
Add scrollbar to Unmanned Systems list when list is long

### DIFF
--- a/src/ui/uas/UASListWidget.cc
+++ b/src/ui/uas/UASListWidget.cc
@@ -51,18 +51,30 @@ UASListWidget::UASListWidget(QWidget *parent) : QWidget(parent),
 {
     m_ui->setupUi(this);
 
-    listLayout = new QVBoxLayout(this);
+    // Setup container for scrollbar
+    mainLayout = new QHBoxLayout(this);
+    mainLayout->setMargin(0);
+    scrollArea = new QScrollArea(this);
+    scrollArea->setWidgetResizable(true);
+    scrollAreaWidgetContents = new QWidget(scrollArea);
+
+    listLayout = new QVBoxLayout(scrollAreaWidgetContents);
     listLayout->setMargin(0);
     listLayout->setSpacing(3);
     listLayout->setAlignment(Qt::AlignTop);
-    this->setLayout(listLayout);
+
+    scrollAreaWidgetContents->setLayout(listLayout);
+    scrollArea->setWidget(scrollAreaWidgetContents);
+
+    mainLayout->addWidget(scrollArea);
+    this->setLayout(mainLayout);
     setObjectName("UNMANNED_SYSTEMS_LIST");
 
     // Construct initial widget
     //uWidget = new QGCUnconnectedInfoWidget(this);
     //listLayout->addWidget(uWidget);
 
-    this->setMinimumWidth(262);
+    this->setMinimumWidth(262 + QApplication::style()->pixelMetric(QStyle::PM_ScrollBarExtent));
 
     uasViews = QMap<UASInterface*, UASView*>();
 
@@ -135,5 +147,19 @@ void UASListWidget::removeUAS(UASInterface* uas)
 
 
     }
+}
+
+void UASListWidget::resizeEvent(QResizeEvent *e)
+{
+    if (scrollArea->verticalScrollBar()->isVisible())
+    {
+        int width = this->width() - QApplication::style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+        scrollAreaWidgetContents->setMaximumWidth(width);
+    }
+    else
+    {
+        scrollAreaWidgetContents->setMaximumWidth(this->width());
+    }
+    update();
 }
 

--- a/src/ui/uas/UASListWidget.h
+++ b/src/ui/uas/UASListWidget.h
@@ -33,6 +33,7 @@ This file is part of the QGROUNDCONTROL project
 
 #include <QWidget>
 #include <QMap>
+#include <QScrollArea>
 #include <QVBoxLayout>
 #include "UASInterface.h"
 #include "UASView.h"
@@ -54,9 +55,13 @@ public slots:
 
 protected:
     QMap<UASInterface*, UASView*> uasViews;
+    QHBoxLayout* mainLayout;
+    QScrollArea* scrollArea;
+    QWidget* scrollAreaWidgetContents;
     QVBoxLayout* listLayout;
     QGCUnconnectedInfoWidget* uWidget;
     void changeEvent(QEvent *e);
+    void resizeEvent(QResizeEvent *e);
 
 private:
     Ui::UASList* m_ui;


### PR DESCRIPTION
When connecting multiple UAVs the Unmanned Systems list will flow off the widget making some UAVs unreachable. This change puts the list in a scrollable widget so that when the list grows long enough a scrollbar will appear and allow you to reach the lowest UAVs.

Without:
![screen shot 2015-03-19 at 6 31 27 pm](https://cloud.githubusercontent.com/assets/8050526/6742713/5cd3c100-ce68-11e4-9c0a-21972ccb19f7.png)

With:
![screen shot 2015-03-19 at 6 42 35 pm](https://cloud.githubusercontent.com/assets/8050526/6742712/5ccc11bc-ce68-11e4-9518-457c8758d837.png)
