### PR TITLE
Map Widget: Add 3D+DGPS and 3D+RTK to GPS-Fix label

### DIFF
--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -257,12 +257,16 @@ public:
     QString getGpsFixString()
     {
         switch(m_gps_fix){
+        case 5:
+            return "3D+RTK";
+        case 4:
+            return "3D+DGPS";
         case 3:
             return "3D";
         case 2:
             return "2D";
         case 1:
-            return "1";
+            return "NO FIX";
         default:
             return ".";
         }

--- a/src/ui/map/QGCMapTool.ui
+++ b/src/ui/map/QGCMapTool.ui
@@ -79,7 +79,7 @@
      <widget class="QLabel" name="satsLabel">
       <property name="geometry">
        <rect>
-        <x>390</x>
+        <x>430</x>
         <y>10</y>
         <width>61</width>
         <height>21</height>
@@ -100,7 +100,7 @@
      <widget class="QLabel" name="hdopLabel">
       <property name="geometry">
        <rect>
-        <x>460</x>
+        <x>500</x>
         <y>10</y>
         <width>71</width>
         <height>21</height>
@@ -123,7 +123,7 @@
        <rect>
         <x>330</x>
         <y>10</y>
-        <width>51</width>
+        <width>91</width>
         <height>21</height>
        </rect>
       </property>
@@ -142,7 +142,7 @@
      <widget class="QLabel" name="zoomLabel">
       <property name="geometry">
        <rect>
-        <x>540</x>
+        <x>580</x>
         <y>10</y>
         <width>71</width>
         <height>21</height>


### PR DESCRIPTION
This PR add 3D+DGPS and 3D+RTK to the QGCMapTool.