### PR TITLE
Main View: fixes #605

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -1838,7 +1838,11 @@ void MainWindow::addLink(int linkid)
 
 void MainWindow::linkError(int linkid,QString errorstring)
 {
-    QMessageBox::information(this,"Link Error",errorstring);
+    QWidget* parent = QApplication::activeWindow();
+    if (!parent) {
+        parent = this;
+    }
+    QMessageBox::information(parent,"Link Error",errorstring);
 }
 
 void MainWindow::simulateLink(bool simulate) {


### PR DESCRIPTION
It was possible that if the comm settings dialog (CommConfigurationWindow) was visible the "Link Error" message box was hidden below the comm settings dialog which makes the main application appearing as non responding