### PR TITLE
Map Widget: Fixes #701 Add auto map caching option

### DIFF
--- a/libs/opmapcontrol/src/mapwidget/mapripform.cpp
+++ b/libs/opmapcontrol/src/mapwidget/mapripform.cpp
@@ -33,21 +33,68 @@ MapRipForm::MapRipForm(QWidget *parent) :
     ui(new Ui::MapRipForm)
 {
     ui->setupUi(this);
+
+    //Hide the progress bars and resize until ripping time
+    ui->frame_rippingInfo->hide();
+    this->resizeForm();
+
+    //Grab the stopping zoom level from the spin box
+    maxAutoRipZoom = ui->spnBoxLevelLimit->value();
 }
 
 MapRipForm::~MapRipForm()
 {
     delete ui;
 }
+
 void MapRipForm::SetPercentage(const int &perc)
 {
     ui->progressBar->setValue(perc);
 }
+
 void MapRipForm::SetProvider(const QString &prov,const int &zoom)
 {
-    ui->mainlabel->setText(QString("Currently ripping from:%1 at Zoom level %2").arg(prov).arg(zoom));
+    ui->lblProvider->setText(QString("Currently ripping from: %1").arg(prov));
+    ui->lblLevel->setText(QString("Current zoom level: %1").arg(zoom));
+
 }
+
 void MapRipForm::SetNumberOfTiles(const int &total, const int &actual)
 {
-    ui->statuslabel->setText(QString("Downloading tile %1 of %2").arg(actual).arg(total));
+    ui->statuslabel->setText(QString("Downloading tile: %1 of %2").arg(actual).arg(total));
 }
+
+void MapRipForm::on_rdoBtn_singleLayer_clicked()
+{
+    emit shouldAutoRip(false);
+}
+
+void MapRipForm::on_rdoBtn_multiLlayer_clicked()
+{
+    emit shouldAutoRip(true);
+}
+
+void MapRipForm::on_spnBoxLevelLimit_valueChanged(int value)
+{
+    maxAutoRipZoom = value;
+}
+
+void MapRipForm::on_pshBtnBeginRip_clicked()
+{
+    ui->frame_rippingInfo->show();
+    this->resizeForm();
+    emit beginRip();
+}
+
+void MapRipForm::on_cancelButton_clicked()
+{
+    emit cancelRip();
+    this->close();
+}
+
+void MapRipForm::resizeForm()
+{
+    resize(0,0);
+}
+
+

--- a/libs/opmapcontrol/src/mapwidget/mapripform.h
+++ b/libs/opmapcontrol/src/mapwidget/mapripform.h
@@ -30,7 +30,7 @@
 #include <QWidget>
 
 namespace Ui {
-    class MapRipForm;
+class MapRipForm;
 }
 
 class MapRipForm : public QWidget
@@ -40,12 +40,29 @@ class MapRipForm : public QWidget
 public:
     explicit MapRipForm(QWidget *parent = 0);
     ~MapRipForm();
+    int maxAutoRipZoom;
+
 public slots:
     void SetPercentage(int const& perc);
     void SetProvider(QString const& prov,int const& zoom);
-    void SetNumberOfTiles(int const& total,int const& actual);
+    void SetNumberOfTiles(int const& total,int const& actual);    
+
+signals:
+    void beginRip();
+    void cancelRip();
+    void shouldAutoRip(bool);
+
+private slots:
+    void on_rdoBtn_multiLlayer_clicked();
+    void on_spnBoxLevelLimit_valueChanged(int value);
+    void on_pshBtnBeginRip_clicked();
+    void on_cancelButton_clicked();
+    void on_rdoBtn_singleLayer_clicked();
+
 private:
     Ui::MapRipForm *ui;
+    void resizeForm();
+
 };
 
 #endif // MAPRIPFORM_H

--- a/libs/opmapcontrol/src/mapwidget/mapripform.ui
+++ b/libs/opmapcontrol/src/mapwidget/mapripform.ui
@@ -6,65 +6,222 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>392</width>
-    <height>133</height>
+    <width>615</width>
+    <height>250</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>MapRipper</string>
   </property>
-  <widget class="QProgressBar" name="progressBar">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>60</y>
-     <width>371</width>
-     <height>23</height>
-    </rect>
-   </property>
-   <property name="value">
-    <number>0</number>
-   </property>
-  </widget>
-  <widget class="QLabel" name="mainlabel">
-   <property name="geometry">
-    <rect>
-     <x>30</x>
-     <y>10</y>
-     <width>321</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Currently ripping from:</string>
-   </property>
-  </widget>
-  <widget class="QLabel" name="statuslabel">
-   <property name="geometry">
-    <rect>
-     <x>30</x>
-     <y>40</y>
-     <width>341</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Downloading tile</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="cancelButton">
-   <property name="geometry">
-    <rect>
-     <x>280</x>
-     <y>100</y>
-     <width>75</width>
-     <height>23</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Cancel</string>
-   </property>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QFrame" name="frame_rippingInfo">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="lblProvider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Currently ripping from:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblLevel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Zoom level:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="statuslabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Downloading tile:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="progressBar">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="rdoBtn_singleLayer">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>300</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Single Layer Cache -- Current Level		</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QRadioButton" name="rdoBtn_multiLlayer">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>320</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Auto Muli-Layer Cache -- Current Level -&gt; Stopping Level: </string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spnBoxLevelLimit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>21</number>
+          </property>
+          <property name="value">
+           <number>19</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>(Default 19)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="pshBtnBeginRip">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Begin</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/libs/opmapcontrol/src/mapwidget/mapripper.cpp
+++ b/libs/opmapcontrol/src/mapwidget/mapripper.cpp
@@ -25,106 +25,172 @@
 * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #include "mapripper.h"
+#include <QSettings>
+#include <QDesktopWidget>
+#include <QApplication>
+#include <QScreen>
+#include <QCursor>
+#include <QDebug>
+
 namespace mapcontrol
 {
 
-    MapRipper::MapRipper(internals::Core * core, const internals::RectLatLng & rect):sleep(100),cancel(false),progressForm(0),core(core)
+MapRipper::MapRipper(internals::Core * core, const internals::RectLatLng & rect):sleep(100),cancel(false),progressForm(0),core(core)
+{
+    if(!rect.IsEmpty())
     {
-        if(!rect.IsEmpty())
+        type=core->GetMapType();
+        progressForm=new MapRipForm;
+        area=rect;
+        zoom=core->Zoom();
+        maxzoom=core->MaxZoom();
+        points=core->Projection()->GetAreaTileList(area,zoom,0);
+        progressForm->show();
+
+        //Move the ripper form to the screen center
+        this->moveFormToCenter();
+
+        connect(this,SIGNAL(percentageChanged(int)),progressForm,SLOT(SetPercentage(int)));
+        connect(this,SIGNAL(numberOfTilesChanged(int,int)),progressForm,SLOT(SetNumberOfTiles(int,int)));
+        connect(this,SIGNAL(providerChanged(QString,int)),progressForm,SLOT(SetProvider(QString,int)));
+        connect(this,SIGNAL(finished()),this,SLOT(finish()));
+        emit numberOfTilesChanged(0,0);
+
+        //Start the ripping when the form button is pressed
+        connect(progressForm,SIGNAL(beginRip()),this,SLOT(start()));
+
+        //Stop the current ripping when the form button is pressed
+        connect(progressForm,SIGNAL(cancelRip()),this,SLOT(cancelRipping()));
+
+        //Connect to the form to see if should auto rip
+        connect(progressForm,SIGNAL(shouldAutoRip(bool)),this,SLOT(setAutoRip(bool)));
+    }
+}
+
+void MapRipper::moveFormToCenter()
+{
+    qDebug() << QApplication::desktop()->screenCount();
+    qDebug() << QApplication::desktop()->screenNumber();
+
+    qDebug() << QGuiApplication::primaryScreen()->name();
+
+    //Grab the current screen size
+    QDesktopWidget* window = QApplication::desktop();
+    QRect screenRec = window->screenGeometry(window->screenNumber(QCursor::pos()));
+    int screenWidth = screenRec.width();
+    int screenHeight = screenRec.height();
+
+    //Get and use the static form size
+    int formWidth = progressForm->geometry().width();
+    int formHeight = progressForm->geometry().height();
+
+    //Move the form to the default center or user saved location
+    progressForm->setGeometry((screenWidth/2)-(formWidth/2),(screenHeight/2)-(formHeight/2), formWidth, formHeight);
+}
+
+void MapRipper::finish()
+{
+    if(zoom<maxzoom && cancel==false)
+    {
+        ++zoom;
+
+        if (shouldAutoRip == true && (zoom <= progressForm->maxAutoRipZoom))
         {
-            type=core->GetMapType();
-            progressForm=new MapRipForm;
-            area=rect;
-            zoom=core->Zoom();
-            maxzoom=core->MaxZoom();
-            points=core->Projection()->GetAreaTileList(area,zoom,0);
-            this->start();
-            progressForm->show();
-            connect(this,SIGNAL(percentageChanged(int)),progressForm,SLOT(SetPercentage(int)));
-            connect(this,SIGNAL(numberOfTilesChanged(int,int)),progressForm,SLOT(SetNumberOfTiles(int,int)));
-            connect(this,SIGNAL(providerChanged(QString,int)),progressForm,SLOT(SetProvider(QString,int)));
-            connect(this,SIGNAL(finished()),this,SLOT(finish()));
-            emit numberOfTilesChanged(0,0);
+            this->doRip();
+        }else{
+
+            if(openMessageBox())
+            {
+                this->doRip();
+            }else{
+                this->stopRipping();
+            }
         }
     }
-    void MapRipper::finish()
+    else
     {
-        if(zoom<maxzoom)
+        this->stopRipping();
+    }
+}
+
+void MapRipper::run()
+{
+    int countOk = 0;
+    bool goodtile=false;
+    //  Stuff.Shuffle<Point>(ref list);
+    QVector<core::MapType::Types> types = OPMaps::Instance()->GetAllLayersOfType(type);
+    int all=points.count();
+    for(int i = 0; i < all; i++)
+    {
+        emit numberOfTilesChanged(all,i+1);
+        if(cancel)
+            break;
+
+        core::Point p = points[i];
         {
-            ++zoom;
-            QMessageBox msgBox;
-            msgBox.setText(QString("Continue Ripping at zoom level %1?").arg(zoom));
-            // msgBox.setInformativeText("Do you want to save your changes?");
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if(ret==QMessageBox::Yes)
+            //qDebug()<<"offline fetching:"<<p.ToString();
+            foreach(core::MapType::Types type,types)
             {
-                points.clear();
-                points=core->Projection()->GetAreaTileList(area,zoom,0);
-                this->start();
+                emit providerChanged(core::MapType::StrByType(type),zoom);
+                QByteArray img = OPMaps::Instance()->GetImageFrom(type, p, zoom);
+                if(img.length()!=0)
+                {
+                    goodtile=true;
+                    img=NULL;
+                }
+                else
+                    goodtile=false;
+            }
+            if(goodtile)
+            {
+                countOk++;
             }
             else
             {
-                    progressForm->close();
-                    delete progressForm;
-                    progressForm=NULL;
-                    this->deleteLater();
+                i--;
+                QThread::msleep(1000);
+                continue;
             }
         }
-        else
-        {
-            progressForm->close();
-            delete progressForm;
-            progressForm=NULL;
-            this->deleteLater();
-        }
-    }
+        emit percentageChanged((int) ((i+1)*100/all));//, i+1);
+        // worker.ReportProgress((int) ((i+1)*100/all), i+1);
 
-
-    void MapRipper::run()
-    {
-        int countOk = 0;
-        bool goodtile=false;
-        //  Stuff.Shuffle<Point>(ref list);
-        QVector<core::MapType::Types> types = OPMaps::Instance()->GetAllLayersOfType(type);
-        int all=points.count();
-        for(int i = 0; i < all; i++)
-        {
-            emit numberOfTilesChanged(all,i+1);
-            if(cancel)
-                break;
-
-            core::Point p = points[i];
-            {
-                //qDebug()<<"offline fetching:"<<p.ToString();
-                foreach(core::MapType::Types type,types)
-                {
-                    emit providerChanged(core::MapType::StrByType(type),zoom);
-                    QByteArray img = OPMaps::Instance()->GetImageFrom(type, p, zoom);
-                    if(img.length()!=0)
-                    {
-                        goodtile=true;
-                        img=NULL;
-                    }
-                    else
-                        goodtile=false;
-                }
-                if(goodtile)
-                {
-                    countOk++;
-                }
-                else
-                {
-                    i--;
-                    QThread::msleep(1000);
-                    continue;
-                }
-            }
-            emit percentageChanged((int) ((i+1)*100/all));//, i+1);
-            // worker.ReportProgress((int) ((i+1)*100/all), i+1);
-
-            QThread::msleep(sleep);
-        }
+        QThread::msleep(sleep);
     }
 }
+
+void MapRipper::doRip()
+{
+    points.clear();
+    points=core->Projection()->GetAreaTileList(area,zoom,0);
+    this->start();
+}
+
+void MapRipper::stopRipping()
+{
+    progressForm->close();
+    delete progressForm;
+    progressForm=NULL;
+    this->deleteLater();
+}
+
+int MapRipper::openMessageBox()
+{
+    QMessageBox msgBox;
+    msgBox.setText(QString("Continue Ripping at zoom level %1?").arg(zoom));
+    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    msgBox.setDefaultButton(QMessageBox::Yes);
+    int ret = msgBox.exec();
+
+    bool cont;
+    if (ret==QMessageBox::Yes)
+        cont = true;
+    else
+        cont = false;
+
+    return cont;
+}
+
+}
+
+

--- a/libs/opmapcontrol/src/mapwidget/mapripper.h
+++ b/libs/opmapcontrol/src/mapwidget/mapripper.h
@@ -40,6 +40,9 @@ namespace mapcontrol
     public:
         MapRipper(internals::Core *,internals::RectLatLng const&);
         void run();
+        void moveFormToCenter();
+        void doRip();
+
     private:
         QList<core::Point> points;
         int zoom;
@@ -50,15 +53,25 @@ namespace mapcontrol
         MapRipForm * progressForm;
         int maxzoom;
         internals::Core * core;
+        bool shouldAutoRip;
+        int openMessageBox();
 
     signals:
         void percentageChanged(int const& perc);
         void numberOfTilesChanged(int const& total,int const& actual);
         void providerChanged(QString const& prov,int const& zoom);
 
-
     public slots:
         void finish();
+        void stopRipping();
+
+        //-- Set functions --//
+        void setAutoRip(bool val){
+            shouldAutoRip = val;
+        }
+        void cancelRipping(){
+            this->cancel=true;
+        }
     };
 }
 #endif // MAPRIPPER_H


### PR DESCRIPTION
Add option when caching maps to auto continue to a desired zoom level. Form allows for both single level and multi-level caching and prompts user at the end of either caching session to stop or continue. Desired zoom level can be changed at any time (unless user prompt is displayed) and will stop at or continue to new desired level. 

![map1](https://cloud.githubusercontent.com/assets/8054027/8552334/71b94dfe-24aa-11e5-8561-34c68c86178a.png)

![map2](https://cloud.githubusercontent.com/assets/8054027/8552336/7539927c-24aa-11e5-8f30-d720545b3710.png)

![map3](https://cloud.githubusercontent.com/assets/8054027/8552338/77a4e4bc-24aa-11e5-95f1-fa9b051560c2.png)