### PR TITLE
Radio Calibration: lower minimum PWM value

### DIFF
--- a/src/ui/configuration/RadioCalibrationConfig.h
+++ b/src/ui/configuration/RadioCalibrationConfig.h
@@ -44,7 +44,7 @@ class RadioCalibrationConfig : public AP2ConfigWidget
 {
     Q_OBJECT
 
-    static const int RC_CHANNEL_PWM_MIN = 895; // Spektrum DX6i reports 898 on ch7 even though its 6 channels
+    static const int RC_CHANNEL_PWM_MIN = 850; // Spektrum DX6i reports 898 on ch7 even though its 6 channels
     static const int RC_CHANNEL_PWM_MAX = 2100;
     static const int RC_CHANNEL_NUM_MAX = 8;
     static const int RC_CHANNEL_LOWER_CONTROL_CH_MAX = 4;


### PR DESCRIPTION
Trying to calibrate a Turnigy 6XS radio is not possible because we get
values around 870usec on some channels. Lower the minimum values so we
can calibrate them.