### PR TITLE
fixed radio uploader problem in Linux build

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -123,9 +123,12 @@ LinuxBuild {
         DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
 
         #MAKE INSTALL - copy files
-        INSTALLS += target datafiles desktopLink menuLink
+        INSTALLS += target radioup datafiles desktopLink menuLink
 
         target.path =$$BINDIR
+        
+	radioup.path = $$BINDIR
+	radioup.files += $$BASEDIR/sik_uploader
 
         datafiles.path = $$DATADIR/APMPlanner2
         datafiles.files += $$BASEDIR/files


### PR DESCRIPTION
this should fix the problem raised in issue #747 
add sik_uploader to the installation in Linux build.
apmplanner is looking for sik_uploader in usr/bin but the files were not installed previously.
This should fixed the problem by installing sik_uploader in /usr/bin