### PR TITLE
Added QDataStream missing include

### DIFF
--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -39,6 +39,7 @@ This file is part of the APM_PLANNER project
 #include <QSqlError>
 #include <QByteArray>
 #include <QDataStream>
+#include <QtCore/QDataStream>
 #include "MAVLinkDecoder.h"
 #include "QsLog.h"
 #include "QGC.h"

--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -37,6 +37,8 @@ This file is part of the APM_PLANNER project
 #include <QSqlQuery>
 #include <QSqlField>
 #include <QSqlError>
+#include <QByteArray>
+#include <QDataStream>
 #include "MAVLinkDecoder.h"
 #include "QsLog.h"
 #include "QGC.h"

--- a/src/ui/CameraView.cc
+++ b/src/ui/CameraView.cc
@@ -31,6 +31,7 @@ This file is part of the QGROUNDCONTROL project
 #include "QsLog.h"
 #include "CameraView.h"
 
+#include <GL/gl.h>
 
 CameraView::CameraView(int width, int height, int depth, int channels, QWidget* parent) : QGLWidget(parent)
 {


### PR DESCRIPTION
It does not compile without it.
The include may replace <QDataStream>, but it compiles+works with both.