### PR TITLE
UI Framework: Enable use of Network Proxies

### DIFF
--- a/libs/opmapcontrol/src/core/opmaps.cpp
+++ b/libs/opmapcontrol/src/core/opmaps.cpp
@@ -118,7 +118,6 @@ namespace core {
                 connect(&network, SIGNAL(finished(QNetworkReply*)),
                         &q, SLOT(quit()));
                 connect(&tT, SIGNAL(timeout()), &q, SLOT(quit()));
-                network.setProxy(Proxy);
 #ifdef DEBUG_GMAPS
                 qDebug()<<"Try Tile from the Internet";
 #endif //DEBUG_GMAPS

--- a/libs/opmapcontrol/src/core/urlfactory.cpp
+++ b/libs/opmapcontrol/src/core/urlfactory.cpp
@@ -38,8 +38,6 @@ namespace core {
         /// timeout for map connections
         /// </summary>
 
-        Proxy.setType(QNetworkProxy::NoProxy);
-
         /// <summary>
         /// Gets or sets the value of the User-agent HTTP header.
         /// </summary>
@@ -106,7 +104,6 @@ namespace core {
             connect(&network, SIGNAL(finished(QNetworkReply*)),
                     &q, SLOT(quit()));
             connect(&tT, SIGNAL(timeout()), &q, SLOT(quit()));
-            network.setProxy(Proxy);
 #ifdef DEBUG_URLFACTORY
             qDebug()<<"Correct GoogleVersion";
 #endif //DEBUG_URLFACTORY
@@ -550,7 +547,6 @@ namespace core {
             QNetworkReply *reply;
             QNetworkRequest qheader;
             QNetworkAccessManager network;
-            network.setProxy(Proxy);
             qheader.setUrl(QUrl(url));
             qheader.setRawHeader("User-Agent",UserAgent);
             reply=network.get(qheader);
@@ -644,7 +640,6 @@ namespace core {
             QNetworkReply *reply;
             QNetworkRequest qheader;
             QNetworkAccessManager network;
-            network.setProxy(Proxy);
             qheader.setUrl(QUrl(url));
             qheader.setRawHeader("User-Agent",UserAgent);
             reply=network.get(qheader);

--- a/libs/opmapcontrol/src/core/urlfactory.h
+++ b/libs/opmapcontrol/src/core/urlfactory.h
@@ -53,7 +53,6 @@ namespace core {
         /// Gets or sets the value of the User-agent HTTP header.
         /// </summary>
         QByteArray UserAgent;
-        QNetworkProxy Proxy;
         UrlFactory();
         ~UrlFactory();
         QString MakeImageUrl(const MapType::Types &type,const core::Point &pos,const int &zoom,const QString &language);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -122,6 +122,11 @@ bool MainWindow::lowPowerModeEnabled()
     return lowPowerMode;
 }
 
+bool MainWindow::autoProxyModeEnabled()
+{
+    return autoProxyMode;
+}
+
 /**
 * Create new mainwindow. The constructor instantiates all parts of the user
 * interface. It does NOT show the mainwindow. To display it, call the show()
@@ -274,6 +279,9 @@ MainWindow::MainWindow(QWidget *parent):
 
     // Set low power mode
     enableLowPowerMode(lowPowerMode);
+
+    // Set Automatic use of system Proxies
+    enableAutoProxyMode(autoProxyMode);
 
     // Initialize window state
     windowStateVal = windowState();
@@ -1236,6 +1244,7 @@ void MainWindow::loadSettings()
     currentStyle = (QGC_MAINWINDOW_STYLE)settings.value("CURRENT_STYLE", QGC_MAINWINDOW_STYLE_OUTDOOR).toInt();
     currentView= static_cast<VIEW_SECTIONS>(settings.value("CURRENT_VIEW", VIEW_FLIGHT).toInt());
     lowPowerMode = settings.value("LOW_POWER_MODE", false).toBool();
+    autoProxyMode = settings.value("AUTO_PROXY_MODE", false).toBool();
     dockWidgetTitleBarEnabled = settings.value("DOCK_WIDGET_TITLEBARS", true).toBool();
     isAdvancedMode = settings.value("ADVANCED_MODE", false).toBool();
     enableHeartbeat(settings.value("HEARTBEATS_ENABLED",true).toBool());
@@ -1249,6 +1258,7 @@ void MainWindow::storeSettings()
     settings.setValue("AUTO_RECONNECT", autoReconnect);
     settings.setValue("CURRENT_STYLE", currentStyle);
     settings.setValue("LOW_POWER_MODE", lowPowerMode);
+    settings.setValue("AUTO_PROXY_MODE", autoProxyMode);
     settings.setValue("ADVANCED_MODE", isAdvancedMode);
     settings.setValue("HEARTBEATS_ENABLED",m_heartbeatEnabled);
     settings.endGroup();
@@ -1363,6 +1373,41 @@ void MainWindow::enableDockWidgetTitleBars(bool enabled)
 void MainWindow::enableAutoReconnect(bool enabled)
 {
     autoReconnect = enabled;
+}
+
+void MainWindow::enableAutoProxyMode(bool enabled)
+{
+    if (enabled)
+    {
+        QLOG_INFO() << "NETWORK_PROXY:" << "Attempting to enable System Network Proxies";
+        QNetworkProxyFactory::setUseSystemConfiguration(true);
+
+        // Check for proxy used for well known external URL
+        QNetworkProxyQuery npq(QUrl("http://www.google.com"));
+        QList<QNetworkProxy> listOfProxies = QNetworkProxyFactory::systemProxyForQuery(npq);
+
+        if (listOfProxies.size() &&
+                QNetworkProxy::NoProxy != listOfProxies[0].type())
+        {
+            QLOG_INFO() << "NETWORK_PROXY:" << "System Proxies in use for external urls";
+            autoProxyMode = enabled;
+        }
+        else
+        {
+            QLOG_ERROR() << "NETWORK_PROXY:" << "No System Proxies found in environment";
+            QNetworkProxyFactory::setUseSystemConfiguration(false);
+        }
+    }
+    else
+    {
+        QLOG_INFO() << "NETWORK_PROXY:" << "Disabling System Network Proxies";
+        QNetworkProxyFactory::setUseSystemConfiguration(false);
+
+        autoProxyMode = enabled;
+    }
+
+    // Ensure the checkbox is in-sync with the current value
+    emit autoProxyChanged(autoProxyMode);
 }
 
 void MainWindow::loadNativeStyle()

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -38,6 +38,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QStackedWidget>
 #include <QSettings>
 #include <qlist.h>
+#include <QNetworkProxy>
 
 #include "ui_MainWindow.h"
 //#include "LinkManager.h"
@@ -118,6 +119,8 @@ public:
     bool dockWidgetTitleBarsEnabled();
     /** @brief Get low power mode setting */
     bool lowPowerModeEnabled();
+    /** @brief Get Auto Prox mode setting */
+    bool autoProxyModeEnabled();
 
     QList<QAction*> listLinkMenuActions(void);
 
@@ -200,6 +203,8 @@ public slots:
     void enableAutoReconnect(bool enabled);
     /** @brief Save power by reducing update rates */
     void enableLowPowerMode(bool enabled) { lowPowerMode = enabled; }
+    /** @brief Use the system proxy for network connections automatically */
+    void enableAutoProxyMode(bool enabled);
     /** @brief Switch to native application style */
     void loadNativeStyle();
     /** @brief Switch to indoor mission style */
@@ -262,6 +267,7 @@ signals:
     /** @brief Forward X11Event to catch 3DMouse inputs */
     void x11EventOccured(XEvent *event);
 #endif //MOUSE_ENABLED_LINUX
+    void autoProxyChanged(bool);
 
 public:
     QGCMAVLinkLogPlayer* getLogPlayer()
@@ -456,6 +462,7 @@ protected:
     bool autoReconnect;
     Qt::WindowStates windowStateVal;
     bool lowPowerMode; ///< If enabled, QGC reduces the update rates of all widgets
+    bool autoProxyMode;
     QPointer<QGCFlightGearLink> fgLink;
     QTimer windowNameUpdateTimer;
 

--- a/src/ui/QGCSettingsWidget.cc
+++ b/src/ui/QGCSettingsWidget.cc
@@ -52,6 +52,11 @@ void QGCSettingsWidget::showEvent(QShowEvent *evt)
         ui->lowPowerCheckBox->setChecked(MainWindow::instance()->lowPowerModeEnabled());
         connect(ui->lowPowerCheckBox, SIGNAL(clicked(bool)), MainWindow::instance(), SLOT(enableLowPowerMode(bool)));
 
+        // Automatic use of system Proxies
+        ui->autoProxyCheckBox->setChecked(MainWindow::instance()->autoProxyModeEnabled());
+        connect(ui->autoProxyCheckBox, SIGNAL(clicked(bool)), MainWindow::instance(), SLOT(enableAutoProxyMode(bool)));
+        connect(MainWindow::instance(), SIGNAL(autoProxyChanged(bool)), ui->autoProxyCheckBox, SLOT(setChecked(bool)));
+
         //Dock widget title bars
         ui->titleBarCheckBox->setChecked(MainWindow::instance()->dockWidgetTitleBarsEnabled());
         connect(ui->titleBarCheckBox,SIGNAL(clicked(bool)),MainWindow::instance(),SLOT(enableDockWidgetTitleBars(bool)));

--- a/src/ui/QGCSettingsWidget.ui
+++ b/src/ui/QGCSettingsWidget.ui
@@ -288,6 +288,20 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="autoProxyCheckBox">
+           <property name="toolTip">
+            <string>Use the system defined network proxies to download data from the Internet through a firewall.</string>
+           </property>
+           <property name="text">
+            <string>Automatically Use System Network Proxies</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../qgroundcontrol.qrc">
+             <normaloff>:/files/images/devices/network-wireless.svg</normaloff>:/files/images/devices/network-wireless.svg</iconset>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="4" column="0">


### PR DESCRIPTION
Fixes Issue #551 Add support for downloading behind a proxy server

Enable the use of QNetworkProxyFactory to automatically
detect and use Network Proxies. This allows the downloading
of map data when behind a firewall.

Functionality can be disabled by setting environment variable
  IGNORE_PROXY