### PR TITLE
UI Framework: Add missing QDataStream include for Qt5.0.0

### DIFF
--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -31,6 +31,7 @@ This file is part of the APM_PLANNER project
 #include <QFile>
 #include <QDebug>
 #include <QStringList>
+#include <QDataStream>
 #include <QDateTime>
 #include <QSqlDatabase>
 #include <QSqlRecord>


### PR DESCRIPTION
This include is missing when compiling with Qt5.5.0.
I also tested successfully this patch with Qt5.4.1.