### PR TITLE
Fix race

### DIFF
--- a/src/ui/configuration/ApmFirmwareConfig.cc
+++ b/src/ui/configuration/ApmFirmwareConfig.cc
@@ -240,6 +240,9 @@ void ApmFirmwareConfig::showEvent(QShowEvent *)
 
 void ApmFirmwareConfig::hideEvent(QHideEvent *)
 {
+    if(m_timer.isSingleShot())
+        return;
+
     // Stop Port scanning
     m_timer.stop();
     if(ui.stackedWidget->currentIndex() == 0)


### PR DESCRIPTION
I got into a recursion inside of MainWindow::instance() because the second call inside ApmFirmwareConfig::hideEvent was being called before the first call to MainWindow::instance() was finished. This happened because of a call to StackedWidget->setCurrentWidget hided the ApmFirmwareConfig, triggering the faulty call.