### PR TITLE
Port to flite2

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -151,7 +151,7 @@ OSGDependency {
     message("Including support for OpenSceneGraph")
 
 	DEFINES += QGC_OSG_ENABLED
-    
+
     LIBS += \
         -losg \
         -losgViewer \
@@ -183,7 +183,7 @@ OSGDependency {
         src/ui/map3D/WaypointGroupNode.h \
         src/ui/map3D/TerrainParamDialog.h \
         src/ui/map3D/ImageryParamDialog.h
-        
+
     SOURCES += \
         src/ui/map3D/gpl.cc \
         src/ui/map3D/CameraParams.cc \
@@ -394,7 +394,7 @@ WindowsBuild : win32 : exists(src/lib/opalrt/OpalApi.h) : exists(C:/OPAL-RT/RT-L
 
     DEFINES += OPAL_RT
 
-    INCLUDEPATH += 
+    INCLUDEPATH +=
         src/lib/opalrt
         libs/lib/opal/include \
 
@@ -466,7 +466,7 @@ WindowsCrossBuild {
 
 LinuxBuild {
 	LIBS += \
-		-lflite_cmu_us_kal \
+		-lflite_cmu_us_kal16 \
 		-lflite_usenglish \
 		-lflite_cmulex \
 		-lflite

--- a/src/GAudioOutput.cc
+++ b/src/GAudioOutput.cc
@@ -62,7 +62,6 @@ extern CComModule _Module;
 #ifdef Q_OS_LINUX
 extern "C" {
 #include <flite/flite.h>
-    cst_voice* register_cmu_us_kal(const char* voxdir);
 };
 #endif
 
@@ -239,7 +238,7 @@ bool GAudioOutput::say(QString text, int severity)
                 if (file.open(QIODevice::ReadWrite))
                 {
                     QLOG_INFO() << file.fileName() << " file not exist, create a new one";
-                    cst_voice *v = register_cmu_us_kal(NULL);
+                    cst_voice *v = new_voice();
                     cst_wave *wav = flite_text_to_wave(text.toStdString().c_str(), v);
                     cst_wave_save(wav, file.fileName().toStdString().c_str(), "riff");
                     file.close();


### PR DESCRIPTION
Just a simple call was needed to port away from flite1, but
the call was not documented in any porting guide.
Also, flite 1 is really hard to find in some distros nowdays, it's good to use a newer version. 

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>