### PR TITLE
UAS: Fix misleading safety switch message. 

### DIFF
--- a/src/uas/ArduPilotMegaMAV.cc
+++ b/src/uas/ArduPilotMegaMAV.cc
@@ -531,7 +531,7 @@ void ArduPilotMegaMAV::textMessageReceived(int /*uasid*/, int /*componentid*/, i
         QString audioString = "Pre-arm check:" + text.remove("PreArm:");
         GAudioOutput::instance()->say(audioString, severity);
     } else if (text.startsWith("Arm:")){
-        QString audioString = "Please press and hold safety switch";
+        QString audioString = "Arm check:" + text.remove("Arm:");
         GAudioOutput::instance()->say(audioString, severity);
     }
 }


### PR DESCRIPTION
There are more messages starting with `Arm:`not only the `safety switch` message. So its confusing that always there is a `Please press and hold safety switch` when the message starts with `Arm:`

https://github.com/diydrones/ardupilot/blob/master/ArduCopter/motors.cpp#L181
https://github.com/diydrones/ardupilot/blob/master/ArduCopter/motors.cpp#L201
https://github.com/diydrones/ardupilot/blob/master/ArduCopter/motors.cpp#L213
https://github.com/diydrones/ardupilot/blob/master/ArduCopter/motors.cpp#L727
https://github.com/diydrones/ardupilot/blob/master/ArduCopter/motors.cpp#L733
...
...
