### PR TITLE
Fix infinite recursion while loading MainWindow v2

### DIFF
--- a/src/ui/configuration/ApmFirmwareConfig.cc
+++ b/src/ui/configuration/ApmFirmwareConfig.cc
@@ -118,9 +118,6 @@ ApmFirmwareConfig::ApmFirmwareConfig(QWidget *parent) : AP2ConfigWidget(parent),
     initConnections();
 
     connect(&m_timer,SIGNAL(timeout()),this,SLOT(populateSerialPorts()));
-    m_timer.setSingleShot(true);
-    m_timer.start(1000);
-
     updateFirmwareButtons();
 }
 
@@ -241,6 +238,9 @@ void ApmFirmwareConfig::showEvent(QShowEvent *)
 void ApmFirmwareConfig::hideEvent(QHideEvent *)
 {
     // Stop Port scanning
+    if (!m_timer.isActive())
+        return;
+
     m_timer.stop();
     if(ui.stackedWidget->currentIndex() == 0)
     {


### PR DESCRIPTION
ApmFirmwareConfig triggered a timer to load the serialPorts
but that should be only populated when the interface is visible,
so I removed the timer call on the constructor.

Also, on the hideEvent of ApmFirmwareConfig we were unconditionally
trying to call MainWindow::instance(), and in some cases the first
call to ::instance() wasn't finished yet ( still on the MainWindow
constructor ) - so we should only act on the hideEvent if m_timer
is active.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>