### PR TITLE
Dont use QObjects in different threads (fix 802)

### DIFF
--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -37,6 +37,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QTimer>
 #include <QList>
 #include <QMutexLocker>
+#include <QtNetwork/qhostaddress.h>
 #include <iostream>
 #include <QHostInfo>
 
@@ -55,18 +56,16 @@ UDPLink::UDPLink(QHostAddress host, quint16 port) :
     this->port = port;
     // Set unique ID and add link to the list of links
     this->id = getNextLinkId();
-	this->name = tr("UDP Link (port:%1)").arg(this->port);
-	emit nameChanged(this->name);
+    this->name = tr("UDP Link (port:%1)").arg(this->port);
+    emit nameChanged(this->name);
     QLOG_INFO() << "UDP Created " << name;
 }
 
 UDPLink::~UDPLink()
 {
-    // Disconnect link from configuration
-    disconnect();
     // Tell the thread to exit
     _running = false;
-    quit();
+
     // Wait for it to exit
     wait();
     while(_outQueue.count() > 0) {
@@ -81,75 +80,61 @@ UDPLink::~UDPLink()
  **/
 void UDPLink::run()
 {
-    if(hardwareConnect()) {
-        if(UDP_BROKEN_SIGNAL) {
-            bool loop = false;
-            while(true) {
-                //-- Anything to read?
-                loop = socket->hasPendingDatagrams();
-                if(loop) {
-                    readBytes();
-                }
-                //-- Loop right away if busy
-                if((_dequeBytes() || loop) && _running)
-                    continue;
-                if(!_running)
-                    break;
-                //-- Settle down (it gets here if there is nothing to read or write)
-                this->msleep(50);
-            }
-        } else {
-            exec();
+    forever {
+        if (!isConnected() && !host.isNull() && port != 0 ) {
+            hardwareConnect();
+            msleep(50);
+            continue;
         }
-    }
-    if (socket) {
-        socket->close();
+
+        if (_shouldRestartConnection) {
+            _shouldRestartConnection = false;
+            hardwareConnect();
+            msleep(50);
+            continue;
+        }
+
+        if (!socket) {
+            msleep(50);
+            continue;
+        }
+
+        bool loop = socket->hasPendingDatagrams();
+        if(loop) {
+            readBytes();
+        }
+
+        //-- Loop right away if busy
+        if((_dequeBytes() || loop) && _running)
+            continue;
+
+        if(!_running)
+            break;
+
+        //-- Settle down (it gets here if there is nothing to read or write)
+        msleep(50);
     }
 }
 
 void UDPLink::restartConnection()
 {
-    if(this->isConnected())
-    {
-        disconnect();
-        connect();
-    }
+    _shouldRestartConnection;
 }
 
 void UDPLink::setAddress(QHostAddress host)
 {
-    bool reconnect(false);
-	if(this->isConnected())
-	{
-		disconnect();
-		reconnect = true;
-	}
     this->host = host;
     emit linkChanged(this);
-
-    if(reconnect)
-	{
-		connect();
-	}
+        _shouldRestartConnection = true;
 }
 
 void UDPLink::setPort(int port)
 {
-	bool reconnect(false);
-	if(this->isConnected())
-	{
-		disconnect();
-		reconnect = true;
-	}
-    this->port = port;
-	this->name = tr("UDP Link (port:%1)").arg(this->port);
-	emit nameChanged(this->name);
+  this->port = port;
+    this->name = tr("UDP Link (port:%1)").arg(this->port);
+    emit nameChanged(this->name);
     emit linkChanged(this);
-
-	if(reconnect)
-	{
-		connect();
-	}
+    _shouldRestartConnection = true;
 }
 
 /**
@@ -193,6 +178,7 @@ void UDPLink::addHost(const QString& host)
         }
     }
     emit linkChanged(this);
+        _shouldRestartConnection = true;
 }
 
 void UDPLink::removeHost(const QString& hostname)
@@ -219,6 +205,7 @@ void UDPLink::removeHost(const QString& hostname)
             ports.removeAt(i);
         }
     }
+    _shouldRestartConnection = true;
 }
 
 void UDPLink::writeBytes(const char* data, qint64 size)
@@ -356,21 +343,7 @@ qint64 UDPLink::bytesAvailable()
 bool UDPLink::disconnect()
 {
     QLOG_INFO() << "UDP disconnect";
-    _running = false;
-	this->quit();
-	this->wait();
-
-    if(socket)
-	{
-        socket->deleteLater();
-		socket = NULL;
-	}
-
-    connectState = false;
-
-    emit disconnected();
-    emit connected(false);
-    emit disconnected(this);
+        _running = false;
     return true;
 }
 
@@ -381,27 +354,9 @@ bool UDPLink::disconnect()
  **/
 bool UDPLink::connect()
 {
-    disconnect();
     QLOG_INFO() << "UDPLink::UDP connect " << host << ":" << port;
-    if(this->isRunning() || _running)
-	{
-        _running = false;
-		this->quit();
-		this->wait();
-	}
-    _running = true;
-    bool connected = this->hardwareConnect();
-    if (connected){
-        emit this->connected(true);
-        emit this->connected(this);
-        emit this->connected();
-    } else {
-        emit this->connected(false);
-        emit disconnected(this);
-        emit disconnected();
-    }
     start(NormalPriority);
-    return connected;
+    return true;
 }
 
 bool UDPLink::hardwareConnect(void)
@@ -415,10 +370,10 @@ bool UDPLink::hardwareConnect(void)
     socket->setProxy(QNetworkProxy::NoProxy);
     connectState = socket->bind(host, port, QAbstractSocket::ReuseAddressHint);
     if (connectState) {
-        //-- Connect signal if this version of Qt is not broken
-        if(!UDP_BROKEN_SIGNAL) {
-            QObject::connect(socket, SIGNAL(readyRead()), this, SLOT(readBytes()));
-        }
+            //-- Connect signal if this version of Qt is not broken
+      //  if(!UDP_BROKEN_SIGNAL) {
+      //      QObject::connect(socket, SIGNAL(readyRead()), this, SLOT(readBytes()));
+      //  }
         emit connected();
         emit connected(true);
         emit connected(this);
@@ -427,7 +382,8 @@ bool UDPLink::hardwareConnect(void)
         emit connected(false);
         emit communicationError("UDP Link Error", "Error binding UDP port");
     }
-	return connectState;
+    _running = true;
+        return connectState;
 }
 
 

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -119,6 +119,7 @@ private:
     int id;
     QUdpSocket* socket;
     bool connectState;
+		bool _shouldRestartConnection;
     QList<QHostAddress> hosts;
     QList<quint16> ports;
 


### PR DESCRIPTION
This code is experimental and by no means should be merged to
master: it still has bugs ( mainly, it broke the connect / disconnect
buttons ).

The code added in 20f7b8f to workaround a Qt bug also created a new
issue: it constantly changed the thread that an object was created
without paying attention about the signal / slot connection nor the
thread ownership.

This code moves all object creation from within the UDPLink object
inside the UDPLink thread, and the communication for the thread
contol is done via boolean flags (_restart, _reconnect, _finish, etc
) that the thread mainloop will certainly hit and do what is requested.

Tested and there is no more crash because of broken UDP content,
unfortunatelly it also broke the interface buttons for connection /
disconnection, but that's easily fixable.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>