### PR TITLE
Dont use QObjects in different threads (fix 802)

### DIFF
--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -119,6 +119,7 @@ private:
     int id;
     QUdpSocket* socket;
     bool connectState;
+    bool _shouldRestartConnection;
     QList<QHostAddress> hosts;
     QList<quint16> ports;
 


### PR DESCRIPTION
The code added in 20f7b8f to workaround a Qt bug also created a new
issue: it constantly changed the thread that an object was created
without paying attention about the signal / slot connection nor the
thread ownership.

This code moves all object creation from within the UDPLink object
inside the UDPLink thread, and the communication for the thread
contol is done via boolean flags (_restart, _reconnect, _finish, etc
) that the thread mainloop will certainly hit and do what is requested.

Since a single approach is usually better than two different approaches
because it's easier to spot a bug and fix it, I removed the
BROKEN_SIGNAL define that was used to create two very different
approaches of the code and used only the code that should work for the
BROKEN_SIGNAL case, since it also should work for the non-broken signal
ones.

Tested and there is no more crash because of broken UDP content,
connection and disconnection of the UDP link works, no more random
crashes on linux because of threads and UDP connection.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>