### PR TITLE
Build: Qt 5.5.1 and Native Windows Builds

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -459,8 +459,8 @@ WindowsCrossBuild {
         $$BASEDIR/libs/lib/sdl/include \
 
         LIBS += \
-        -Llibs/lib/sdl/win32 \
-        -lSDL2.dll
+        -L$$BASEDIR/libs/lib/sdl/win32 \
+        -lSDL2
 }
 
 #

--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -367,22 +367,25 @@ LinuxBuild : exists(/usr/local/lib/libxdrvlib.so) {
 }
 
 WindowsBuild {
-    message("Including support for Magellan 3DxWare")
+#    if defined(MOUSE_ENABLED_WIN)
+#    message("Including support for Magellan 3DxWare")
 
-    DEFINES += MOUSE_ENABLED_WIN
+#    DEFINES += MOUSE_ENABLED_WIN
 
-    INCLUDEPATH += libs/thirdParty/3DMouse/win
+#    INCLUDEPATH += libs/thirdParty/3DMouse/win
 
-    HEADERS += \
-        libs/thirdParty/3DMouse/win/I3dMouseParams.h \
-        libs/thirdParty/3DMouse/win/MouseParameters.h \
-        libs/thirdParty/3DMouse/win/Mouse3DInput.h \
-        src/input/Mouse6dofInput.h
+#    HEADERS += \
+#        libs/thirdParty/3DMouse/win/I3dMouseParams.h \
+#        libs/thirdParty/3DMouse/win/MouseParameters.h \
+#        libs/thirdParty/3DMouse/win/Mouse3DInput.h \
+#        src/input/Mouse6dofInput.h
 
-    SOURCES += \
-        libs/thirdParty/3DMouse/win/MouseParameters.cpp \
-        libs/thirdParty/3DMouse/win/Mouse3DInput.cpp \
-        src/input/Mouse6dofInput.cpp
+#    SOURCES += \
+#        libs/thirdParty/3DMouse/win/MouseParameters.cpp \
+#        libs/thirdParty/3DMouse/win/Mouse3DInput.cpp \
+#        src/input/Mouse6dofInput.cpp
+#    endif
+    message("Skipping support for Magellan 3DxWare")
 }
 
 #

--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -17,40 +17,42 @@
 # along with QGroundControl. If not, see <http://www.gnu.org/licenses/>.
 # -------------------------------------------------
 
-QMAKE_POST_LINK += $$quote(echo "Copying files")
+QMAKE_POST_LINK += echo "Copying files"
 
 #
 # Copy the application resources to the associated place alongside the application
 #
 
-COPY_RESOURCE_LIST = \
-    $$BASEDIR/files \
-    $$BASEDIR/qml \
-    $$BASEDIR/data \
-    $$BASEDIR/sik_uploader
-    
-WindowsBuild {
-	DESTDIR_COPY_RESOURCE_LIST = $$replace(DESTDIR,"/","\\")
-    COPY_RESOURCE_LIST = $$replace(COPY_RESOURCE_LIST, "/","\\")
-    CONCATCMD = $$escape_expand(\\n)
-}
+# Dev note: Used to move "files","data","sik_uploader", and "qml".
+# Fow now only the last two
 
 LinuxBuild {
     DESTDIR_COPY_RESOURCE_LIST = $$DESTDIR
-    CONCATCMD = &&
+    QMAKE_POST_LINK += && $$QMAKE_COPY_DIR $$BASEDIR/qml $$DESTDIR_COPY_RESOURCE_LIST
+    QMAKE_POST_LINK += && $$QMAKE_COPY_DIR $$BASEDIR/sik_uploader $$DESTDIR_COPY_RESOURCE_LIST
 }
 
 MacBuild {
     DESTDIR_COPY_RESOURCE_LIST = $$DESTDIR/$${TARGET}.app/Contents/MacOS
-    CONCATCMD = &&
+    QMAKE_POST_LINK += && $$QMAKE_COPY_DIR $$BASEDIR/qml $$DESTDIR_COPY_RESOURCE_LIST
+    QMAKE_POST_LINK += && $$QMAKE_COPY_DIR $$BASEDIR/sik_uploader $$DESTDIR_COPY_RESOURCE_LIST
 }
-    
-for(COPY_DIR, COPY_RESOURCE_LIST):QMAKE_POST_LINK += $$CONCATCMD $$QMAKE_COPY_DIR $${COPY_DIR} $$DESTDIR_COPY_RESOURCE_LIST
+
+# Windows version of QMAKE_COPY_DIR of course doesn't work the same as Mac/Linux. It will only
+# copy the contents of the source directory. It doesn't create the top level source directory
+# in the target.
+WindowsBuild {
+    # Make sure to keep both side of this if using the same set of directories
+    DESTDIR_COPY_RESOURCE_LIST = $$replace(DESTDIR,"/","\\")
+    BASEDIR_COPY_RESOURCE_LIST = $$replace(BASEDIR,"/","\\")
+    QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$BASEDIR_COPY_RESOURCE_LIST\\qml\" \"$$DESTDIR_COPY_RESOURCE_LIST\\qml\"
+    QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$BASEDIR_COPY_RESOURCE_LIST\\sik_uploader\" \"$$DESTDIR_COPY_RESOURCE_LIST\\sik_uploader\"
+}
 
 #
 # Perform platform specific setup
 #
-message(QTDIR $$[QT_INSTALL_PREFIX])
+
 MacBuild {
     # Copy libraries and frameworks into app package
     QMAKE_POST_LINK += && $$QMAKE_COPY_DIR -L $$BASEDIR/libs/lib/Frameworks $$DESTDIR/$${TARGET}.app/Contents/Frameworks
@@ -62,56 +64,20 @@ MacBuild {
 }
 
 WindowsBuild {
-	# Copy dependencies
-	BASEDIR_WIN = $$replace(BASEDIR,"/","\\")
-	DESTDIR_WIN = $$replace(DESTDIR,"/","\\")
 
-    QMAKE_POST_LINK += $$escape_expand(\\n) $$quote($$QMAKE_COPY_DIR "$$(QTDIR)\\plugins" "$$DESTDIR_WIN")
+    BASEDIR_WIN = $$replace(BASEDIR,"/","\\")
+    DESTDIR_WIN = $$replace(DESTDIR,"/","\\")
 
-    COPY_FILE_DESTDIR = $$DESTDIR_WIN
-	DebugBuild: DLL_QT_DEBUGCHAR = "d"
+    # Copy dependencies
+    DebugBuild: DLL_QT_DEBUGCHAR = "d"
     ReleaseBuild: DLL_QT_DEBUGCHAR = ""
     COPY_FILE_LIST = \
         $$BASEDIR_WIN\\libs\\lib\\sdl\\win32\\SDL2.dll \
         $$BASEDIR_WIN\\libs\\thirdParty\\libxbee\\lib\\libxbee.dll \
-        $$(QTDIR)\\bin\\Qt5WebKitWidgets$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5MultimediaWidgets$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Multimedia$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Gui$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Core$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\icuin51.dll \
-        $$(QTDIR)\\bin\\icuuc51.dll \
-        $$(QTDIR)\\bin\\icudt51.dll \
-        $$(QTDIR)\\bin\\Qt5Network$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Widgets$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5OpenGL$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5PrintSupport$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5WebKit$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Quick$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Qml$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Sql$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Positioning$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Sensors$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Declarative$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5XmlPatterns$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Xml$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Script$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Svg$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5Test$${DLL_QT_DEBUGCHAR}.dll \
-        $$(QTDIR)\\bin\\Qt5SerialPort$${DLL_QT_DEBUGCHAR}.dll
 
     for(COPY_FILE, COPY_FILE_LIST) {
-        QMAKE_POST_LINK += $$escape_expand(\\n) $$quote($$QMAKE_COPY "$$COPY_FILE" "$$COPY_FILE_DESTDIR")
+        QMAKE_POST_LINK += $$escape_expand(\\n) $$quote($$QMAKE_COPY "$$COPY_FILE" "$$DESTDIR_WIN")
     }
-
-    # Copy Qml libraries
-    Q_DIR = $$[QT_INSTALL_QML]
-    QML_DIR_WIN = $$replace(Q_DIR, "/", "\\")
-    #QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$QML_DIR_WIN\\QtGraphicalEffects\" \"$$DESTDIR_WIN\\QtGraphicalEffects\"
-    QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$QML_DIR_WIN\\QtQuick\" \"$$DESTDIR_WIN\\QtQuick\"
-    QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$QML_DIR_WIN\\QtQuick.2\" \"$$DESTDIR_WIN\\QtQuick.2\"
-    #QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$QML_DIR_WIN\\QtLocation\" \"$$DESTDIR_WIN\\QtLocation\"
-    #QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$QML_DIR_WIN\\QtPositioning\" \"$$DESTDIR_WIN\\QtPositioning\"
 
     ReleaseBuild {
         # Copy Visual Studio DLLs
@@ -132,7 +98,8 @@ WindowsBuild {
                 error("Visual studio version not supported, installation cannot be completed.")
         }
     }
-
+    DEPLOY_TARGET = $$shell_quote($$shell_path($$DESTDIR_WIN\\$${TARGET}.exe))
+    QMAKE_POST_LINK += $$escape_expand(\\n) windeployqt --no-compiler-runtime --qmldir=$${BASEDIR_WIN}\\qml $${DEPLOY_TARGET}
 }
 
 LinuxBuild {

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ https://github.com/diydrones/apm_planner
 Credits:
 http://planner2.ardupilot.com/credits-and-contributors/
 
-Developer Chat: https://gitter.im/diydrones/apm_planner
-
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/diydrones/apm_planner?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Developer Chat: [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/diydrones/apm_planner?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [Waffle.io](https://waffle.io/diydrones/apm_planner) Progress Graph
 
@@ -115,160 +113,37 @@ This will place the binary in your /bin/ folder and corresponding files in /shar
 Windows
 =======
 
-You have three options in Windows. These are listed from easiest to most difficult
+To build on Windows:
+* Both 32 and 64 bit applications are supported, the following steps can be used for either. 
+* Install Qt 5.5.1 32bit MSVC2013 with the [Qt installer](http://www.qt.io/download-open-source).
+* Install the [Visual Studio 2013 compiler](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop).
 
-* Option 1: VS2010 should work with makefiles and nmake.
-* Option 2: Mingw: This should work, no guarantees.
-* Option 3: VS2012 requires a recompile of Qt, but otherwise should work with makefiles and nmake. This will not be described here.
-
-
-Option 1: VS2010 [TODO: Update for Qt5]
--------
-
-1. Download MSVc2010 express edition (You need SP1). You can get it from the Microsoft website
-2. Download Qt libraries for windows (5.2.1, for MSVC2010(TODO?)) from http://qt-project.org/downloads
-3. Download and install QtCreator
-4. Download and install msysgit http://msysgit.github.io/
-    - Open up git bash
-    - git clone git://github.com/diydrones/apm_planner.git
-    - Ensure that msysgit's bin folder is in your path, as it has touch.exe which is needed for the build
-5. Start QtCreator and configure QtCreator:
+Check QtCreator configuration:
+* Start QtCreator
     - click on the Tools menu item then Options
     - Select Build & Run on the left hand side
     - Compilers tab
-        * Ensure Microsoft visual c++ Compiler 10.0 shows up under Auto-Detected
-        * click Add and select MinGW
-        * Find where you installed your compiler, inside the bin directory select g++.exe
-        * Click apply
+        * Ensure Microsoft Visual C++ Compiler 12.0 is listed under Auto-detected
     - Qt Versions Tab:
-        * click Add
-        * Find qmake.exe (typically in c:\Qt\5.2.1\bin\qmake.exe)
-        * click Apply
+		* Ensure Qt 5.5.1 MSVC2013 32bit is listed under Auto-detected
+		* If Qt 5.5.1 MSVC2013 32bit is not listed:
+			- Click Add
+			- Find the qmake.exe (typically in c:\Qt\5.5.1\bin\qmake.exe)
+			- Click Apply
     - Kits tab:
-        * Click Add, name it Qt 5.2.1 - MSVC
-        * Select the MSVC compiler, and Qt version you just created.
-        * click Apply
+        * Ensure Desktop Qt 5.5.1 MSVC2013 32bit is listed under Auto-detected
+		* If Qt 5.5.1 MSVC2013 32bit is not listed:
+			- Click Add, name it Qt 5.5.1 MSVC 32bit
+			- Select the MSVC compiler (Microsoft Visual C++ Compiler 12.0 (x86)
+			- Select the Qt version (Qt 5.5.1 MSVC2013 32bit)
+			- Click Apply
     - Click Ok
-6. QtCreator is now configured.
-7. Click on File then Open, find qgroundcontrol.pro
-    - It will ask you to configure project, you want to make sure Qt 5.2.1 - MSVC is selected, and click "Configure Project"
-8. Go to "Projects" tab on the left hand side, deselect "Shadow Build".
-9. Build->Build qgroundcontrol
-10. Run and enjoy!
+* QtCreator is now configured.
+* Click on File then Open, find qgroundcontrol.pro
+    - It will ask you to configure project, you want to make sure Qt 5.5.1 MSVC 32bit is selected, and click "Configure Project"
+* Go to "Projects" tab on the left hand side, ensure "Shadow Build" is selected.
+* Build->Build qgroundcontrol
+* Run and enjoy!
 
-
-
-Option 2: MinGW [TODO: update for Qt5]
--------
-
-Install everything to a path where there are NO spaces. This is important.
-
-1. Download Mingw 5.2.1 from http://sourceforge.net/projects/mingwbuilds/ (mingw-builds-install.exe)
-    - Install with options: x32 5.2.1 posix dwarf rev5
-2. Download and install Qt libraries for Windows (5.2.1, for MINGW 5.2.1) from http://qt-project.org/downloads
-3. Download and install QtCreator
-4. Download and install msysgit http://msysgit.github.io/
-    - Open up Git Bash
-    - git clone git://github.com/diydrones/apm_planner.git
-5. Start QtCreator and configure QtCreator:
-    - click on the Tools menu item then Options
-    - Select Build & Run on the left hand side
-    - Compilers tab
-        * click Add and select MinGW
-        * Find where you installed your compiler, inside the bin directory select g++.exe
-        * Click apply
-    - Debuggers Tab:
-        * Click Add
-        * Find gdb.exe, it will be in the same folder as g++.exe
-        * Click Apply
-    - Qt Versions Tab:
-        * click Add
-        * Find qmake.exe (typically in c:\Qt\5.2.1\bin\qmake.exe)
-        * click Apply
-    - Kits tab:
-        * Click Add, name it Qt 5.2.1 - MinGW
-        * Select the compiler, debugger, and Qt version you just created.
-        * click Apply
-        * Click Ok
-6. QtCreator is now configured.
-7. Click on File then Open, find qgroundcontrol.pro
-    - It will ask you to configure project, you want to make sure Qt 5.2.1 - MinGW is selected, and click "Configure Project"
-8. Go to "Projects" tab on the left hand side, deselect "Shadow Build".
-9. Build->Build qgroundcontrol
-10. Run and enjoy!
-
-
-Repository Layout (2014-3-28: out-of-date, needs to be fixed)
-=================
-```
-qgroundcontrol:
-	demo-log.txt
-	license.txt 
-	qgcunittest.pro - For the unit tests.
-	qgcunittest.pro.user
-	qgcvideo.pro
-	qgroundcontrol.pri - Used by qgroundcontrol.pro
-	qgroundcontrol.pro - Project opened in QT to run qgc.
-	qgroundcontrol.pro.user 
-	qgroundcontrol.qrc - Holds many images.
-	qgroundcontrol.rc - line of code to point toward the images
-	qserialport.pri - generated by qmake.
-	testlog.txt
-	testlog2.txt 
-	user_config.pri.dist - Custom message specs to be added here. 
-data: 
-	Maps from yahoo and kinect and earth. 
-deploy: 
-	Install and uninstall for win32.
-	Create a debian packet.
-	Create .DMG file for publishing for mac.
-	Audio test on mac.	
-doc: 
-	Doxyfile is in this directory and information for creating html documentation for qgc.
-files: 
-	Has the audio for the vehicle and data output. 
-		ardupilotmega: 
-			widgets and tool tips for pilot heading for the fixed wing.
-			tooltips for quadrotor
-		flightgear:
-			Aircraft: 
-				Different types of planes and one jeep. 
-			Protocol: 
-				The protocol for the fixed_wings and quadrotor and quadhil.holds info about the fixed wing yaw, roll etc. 					Quadrotor. Agian holds info about yaw, roll etc.
-		Pixhawk:
-			Widgets for hexarotor. Widgets and tooltips for quadrotor.
-		vehicles: 
-			different vehicles. Seems to hold the different kinds of aircrafts as well as files for audio and the hexarotor 			and quadrotor.
-		widgets: 
-			Has a lot of widgets defined for buttons and sliders.
-
-images: 
-	For the UI. Has a bunch of different images such as images for applications or actions or buttons.
-lib: 
-	SDL is located in this direcotry. 
-	Msinttypes: 
-		Defines intteger types for microsoft visual studio. 
-	sdl:
-		Information about the library and to run the library on different platforms. 
-mavlink: 
-	The files for the library mavlink. 
-qgcunittest: 
-	Has the unittests for qgc
-settings: 
-	Parameter lists for alpha, bravo and charlie. 
-	Data for stereo, waypoints and radio calibrartion. 
-src:
-	Code for QGCCore, audio output, configuration, waypoints, main and log compressor.
-	apps - Code for mavlink generation and for a video application.
-	comm - Code for linking to simulation, mavlink, udp, xbee, opal, flight gear and interface.
-	Has other libraries. Qwt is in directory named lib. The other libraries are in libs.
-	lib - qwt library
-	libs - eigen, opmapcontrol, qestserialport, qtconcurrent, utils.
-	input - joystick and freenect code.
-	plugins - Qt project for PIXHAWK plugins.
-	uas - Ardu pilot, UAS, mavlink factory, uas manager, interface, waypoint manager and slugs.
-	ui - Has code for data plots, waypoint lists and window congfiguration. All of the ui code.
-thirdParty: 
-	Library called lxbee.
-	Library called QSerialPort.
-```
+Installing this compiled version: 
+* To Do

--- a/README.md
+++ b/README.md
@@ -113,37 +113,66 @@ This will place the binary in your /bin/ folder and corresponding files in /shar
 Windows
 =======
 
-To build on Windows:
-* Both 32 and 64 bit applications are supported, the following steps can be used for either. 
-* Install Qt 5.5.1 32bit MSVC2013 with the [Qt installer](http://www.qt.io/download-open-source).
-* Install the [Visual Studio 2013 compiler](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop).
+To build on Windows there are two options:
+* Option 1: Visual Studio 2013 native compile
+    * Download and install [Visual Studio 2013 express](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-desktop)
+* Option 2: MinGW cross-compile
 
-Check QtCreator configuration:
+Install Qt with the [online Qt installer](http://www.qt.io/download-open-source): 
+* You will be presented with a list of Qt versions and compiler options to install
+* You can install mulitple versions and compilers beside one another and choose which to use later 
+* Select any one (or mulitple) of the following options, 
+	* Qt 5.5 MSVC2013 32-bit
+	* Qt 5.5 MSVC2013 64-bit
+	* Qt 5.5 MinGW 4.9.2 32-bit (also select the same version of MinGW under Tools)
+
+Configure QtCreator:
+* The installer is pretty smart but it's good to double check everything was setup corretly
 * Start QtCreator
-    - click on the Tools menu item then Options
-    - Select Build & Run on the left hand side
-    - Compilers tab
-        * Ensure Microsoft Visual C++ Compiler 12.0 is listed under Auto-detected
-    - Qt Versions Tab:
-		* Ensure Qt 5.5.1 MSVC2013 32bit is listed under Auto-detected
-		* If Qt 5.5.1 MSVC2013 32bit is not listed:
-			- Click Add
-			- Find the qmake.exe (typically in c:\Qt\5.5.1\bin\qmake.exe)
-			- Click Apply
-    - Kits tab:
-        * Ensure Desktop Qt 5.5.1 MSVC2013 32bit is listed under Auto-detected
-		* If Qt 5.5.1 MSVC2013 32bit is not listed:
-			- Click Add, name it Qt 5.5.1 MSVC 32bit
-			- Select the MSVC compiler (Microsoft Visual C++ Compiler 12.0 (x86)
-			- Select the Qt version (Qt 5.5.1 MSVC2013 32bit)
-			- Click Apply
-    - Click Ok
-* QtCreator is now configured.
-* Click on File then Open, find qgroundcontrol.pro
-    - It will ask you to configure project, you want to make sure Qt 5.5.1 MSVC 32bit is selected, and click "Configure Project"
-* Go to "Projects" tab on the left hand side, ensure "Shadow Build" is selected.
-* Build->Build qgroundcontrol
-* Run and enjoy!
+    * Click on the *Tools* menu item then *Options*
+    * Select *Build & Run* on the left hand side
+    * Look at the *Compilers* tab
+        * Under *Auto-detected* should be a list of compilers installed, such as:
+            * Microsoft Visual C++ Compiler 12.0 (x86)
+            * Microsoft Visual C++ Compiler 12.0 (amd64)
+            * MinGW 4.9.2 32bit
+        * If using MSVC there will be a few others listed as well but that is normal
+    * Look at the *Qt Versions* Tab:
+        * Under *Auto-detected* should be a list of the Qt versions you installed earlier:
+		    * Qt 5.5.1 MSVC2013 32bit
+		    * Qt 5.5.1 MSVC2013 32bit
+		    * Qt 5.5.1 MinGW 32bit
+		* If your desired Qt versions is not listed, or you installed one after the initial setup:
+			* Click Add
+			* Find the qmake.exe for the version you want
+			    * For example: c:/Qt/5.5/msvc2013/bin/qmake.exe
+			    * For example: c:/Qt/5.5/mingw492_32/bin/qmake.exe
+			* Click Apply
+    * Look under the *Kits* tab:
+        * Under *Auto-detected* should be a list of the appropriate kits:
+            * Desktop Qt 5.5.1 MSVC2013 32bit
+            * Desktop Qt 5.5.1 MSVC2013 63bit
+            * Desktop Qt 5.5.1 MinGB 32bit
+		* If a kit with your desired Qt versions and/or compiler is not listed, or you installed a new Qt version or compiler after the initial setup:
+			* Click *Add*, give it a nice name (like Qt 5.5.1 MSVC 32bit)
+			* Select the desired compiler from the drop down
+			* Select the Qt version (with matching compiler) from the drop down
+			* Click Apply
+    - Click *Ok* at the bottom of the window
+* QtCreator is now configured for fun
+
+Build APM Planner 2.0:
+* Start QtCreator (if not already)
+* Click on *File* then *Open File or Project*
+* Find qgroundcontrol.pro, then click *Open*
+    * The first time will ask you to configure project
+    * Select the desired version (same list of Kits from above) 
+    * Click *Configure Project*
+* Go to *Projects* tab on the left hand side
+    * Select the "Shadow Build" checkbox
+    * Browse to a location where you want the application to build to
+* From the *Build* drop down select *Build Project qgroundcontrol* (or Ctrl+B)
+* Run the generated apmplanner2.exe and enjoy!
 
 Installing this compiled version: 
 * To Do

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -49,11 +49,11 @@ linux-g++-64 {
     contains( DISTRO, "Ubuntu" ) {
          DEFINES += Q_UBUNTU
     }
-} else : win32-msvc2013 {
+} else : win32-msvc2010 | win32-msvc2012 | win32-msvc2013 {
     message(Windows build)
     CONFIG += WindowsBuild
 }  else : win32-g++|win64-g++ {
-    error("Windows cross build is unsupported, MSVC required")
+    message("Windows cross build")
     CONFIG += WindowsCrossBuild
 } else : macx-clang | macx-g++ {
     message(Mac build)

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -25,6 +25,10 @@
 
 message(Qt version $$[QT_VERSION])
 
+!equals(QT_MAJOR_VERSION, 5) | !greaterThan(QT_MINOR_VERSION, 3) {
+    error("Unsupported Qt version, 5.4+ is required")
+}
+
 # Setup our supported build types. We do this once here and then use the defined config scopes
 # to allow us to easily modify suported build types in one place instead of duplicated throughout
 # the project file.
@@ -45,12 +49,11 @@ linux-g++-64 {
     contains( DISTRO, "Ubuntu" ) {
          DEFINES += Q_UBUNTU
     }
-
-} else : win32-msvc2008 | win32-msvc2010 | win32-msvc2012 {
+} else : win32-msvc2013 {
     message(Windows build)
     CONFIG += WindowsBuild
-}  else : win32-x-g++|win64-x-g++ {
-    message(Windows Cross Build)
+}  else : win32-g++|win64-g++ {
+    error("Windows cross build is unsupported, MSVC required")
     CONFIG += WindowsCrossBuild
 } else : macx-clang | macx-g++ {
     message(Mac build)
@@ -113,11 +116,12 @@ QT += network \
 ##  testlib is needed even in release flavor for QSignalSpy support
 QT += testlib
 
-!NOTOUCH {
-    gittouch.commands = touch qgroundcontrol.pro
-    QMAKE_EXTRA_TARGETS += gittouch
-    POST_TARGETDEPS += gittouch
-}
+#Not sure what we were doing here, will have to ask
+#!NOTOUCH {
+#    gittouch.commands = touch qgroundcontrol.pro
+#    QMAKE_EXTRA_TARGETS += gittouch
+#    POST_TARGETDEPS += gittouch
+#}
 
 # Turn off serial port warnings
 DEFINES += _TTY_NOWARN_
@@ -307,7 +311,7 @@ FORMS += \
     src/ui/ParameterInterface.ui \
     src/ui/WaypointList.ui \
     src/ui/ObjectDetectionView.ui \
-    src/ui/JoystickWidget.ui \
+    #src/ui/JoystickWidget.ui \
     src/ui/HDDisplay.ui \
     src/ui/MAVLinkSettingsWidget.ui \
     src/ui/AudioOutputWidget.ui \
@@ -455,7 +459,7 @@ HEADERS += \
     src/configuration.h \
     src/ui/uas/UASView.h \
 #if defined(CAMERAVIEW)
-    src/ui/CameraView.h \
+    #src/ui/CameraView.h \
 #endif
     src/comm/MAVLinkSimulationLink.h \
     src/comm/UDPLink.h \
@@ -466,8 +470,8 @@ HEADERS += \
     src/ui/WaypointNavigation.h \
     src/Waypoint.h \
     src/ui/ObjectDetectionView.h \
-    src/input/JoystickInput.h \
-    src/ui/JoystickWidget.h \
+    #src/input/JoystickInput.h \
+    #src/ui/JoystickWidget.h \
     src/ui/HDDisplay.h \
     src/ui/MAVLinkSettingsWidget.h \
     src/ui/AudioOutputWidget.h \
@@ -682,7 +686,7 @@ SOURCES += src/main.cc \
     src/ui/HUD.cc \
     src/ui/uas/UASView.cc \
 #ifdef CAMERAVIEW
-    src/ui/CameraView.cc \
+    #src/ui/CameraView.cc \
 #endif
     src/comm/MAVLinkSimulationLink.cc \
     src/comm/UDPLink.cc \
@@ -693,8 +697,8 @@ SOURCES += src/main.cc \
     src/ui/WaypointNavigation.cc \
     src/Waypoint.cc \
     src/ui/ObjectDetectionView.cc \
-    src/input/JoystickInput.cc \
-    src/ui/JoystickWidget.cc \
+    #src/input/JoystickInput.cc \
+    #src/ui/JoystickWidget.cc \
     src/ui/HDDisplay.cc \
     src/ui/MAVLinkSettingsWidget.cc \
     src/ui/AudioOutputWidget.cc \
@@ -945,5 +949,3 @@ OTHER_FILES += \
 
 DISTFILES += \
     qml/components/BarGauge.qml
-
-

--- a/src/QGC.h
+++ b/src/QGC.h
@@ -34,25 +34,25 @@
 #define define2string_p(x) #x
 #define define2string(x) define2string_p(x)
 
-/* Windows fixes */
-#ifdef _MSC_VER
-/* Needed define for Eigen */
-//#define NOMINMAX
-#include <limits>
-template<typename T>
-inline bool isnan(T value)
-{
-    return value != value;
+///* Windows fixes */
+//#ifdef _MSC_VER
+///* Needed define for Eigen */
+////#define NOMINMAX
+//#include <limits>
+//template<typename T>
+//inline bool isnan(T value)
+//{
+//    return value != value;
 
-}
+//}
 
-// requires #include <limits>
-template<typename T>
-inline bool isinf(T value)
-{
-    return (value == std::numeric_limits<T>::infinity() || (-1*value) == std::numeric_limits<T>::infinity()) && std::numeric_limits<T>::has_infinity;
-}
-#else
+//// requires #include <limits>
+//template<typename T>
+//inline bool isinf(T value)
+//{
+//    return (value == std::numeric_limits<T>::infinity() || (-1*value) == std::numeric_limits<T>::infinity()) && std::numeric_limits<T>::has_infinity;
+//}
+//#else
 #include <cmath>
 #if defined(Q_OS_MACX) || defined(Q_OS_WIN)
 #ifndef isnan
@@ -62,7 +62,7 @@ inline bool isinf(T value)
 #define isinf(x) std::isinf(x)
 #endif
 #endif
-#endif
+//#endif
 
 namespace QGC
 {

--- a/src/QGCCore.cc
+++ b/src/QGCCore.cc
@@ -52,6 +52,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QStyleFactory>
 #include <QAction>
 
+
 /**
  * @brief Constructor for the main application.
  *
@@ -81,8 +82,8 @@ void QGCCore::initialize()
 {
     QLOG_INFO() << "QGCCore::initialize()";
     QLOG_INFO() << "Current Build Info";
-    QLOG_INFO() << "Git Hash:" << define2string(GIT_HASH);
-    QLOG_INFO() << "Git Commit:" << define2string(GIT_COMMIT);
+    QLOG_INFO() << "Git Hash:" << QString(define2string(GIT_HASH));
+    QLOG_INFO() << "Git Commit:" << QString(define2string(GIT_COMMIT));
     QLOG_INFO() << "APPLICATION_NAME:" << define2string(QGC_APPLICATION_NAME);
     QLOG_INFO() << "APPLICATION_VERSION:" << define2string(QGC_APPLICATION_VERSION);
     QLOG_INFO() << "APP_PLATFORM:" << define2string(APP_PLATFORM);

--- a/src/ui/AboutDialog.cc
+++ b/src/ui/AboutDialog.cc
@@ -15,8 +15,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui->appnameLabel->setText(tr("%1 %2").arg(QGC_APPLICATION_NAME).arg(QGC_APPLICATION_VERSION));
     QString hash = QString(define2string(GIT_HASH));
     hash.truncate(8);
-    ui->versionLabel->setText(tr("(%1-%2)").arg(hash)
-                               .arg(define2string(GIT_COMMIT)));
+    ui->versionLabel->setText(tr("(%1-%2)").arg(hash).arg(QString(define2string(GIT_COMMIT))));
     ui->linkLabel->setOpenExternalLinks(true);
 }
 

--- a/src/ui/DebugOutput.cc
+++ b/src/ui/DebugOutput.cc
@@ -5,8 +5,8 @@
 DebugOutput::DebugOutput(QWidget *parent) : QWidget(parent), QsLogging::Destination()
 {
     ui.setupUi(this);
-    ui.hashLineEdit->setText(define2string(GIT_HASH));
-    ui.commitLineEdit->setText(define2string(GIT_COMMIT));
+    ui.hashLineEdit->setText(QString(define2string(GIT_HASH)));
+    ui.commitLineEdit->setText(QString(define2string(GIT_COMMIT)));
     connect(ui.onTopCheckBox,SIGNAL(clicked(bool)),this,SLOT(onTopCheckBoxChecked(bool)));
     connect(ui.copyPushButton,SIGNAL(clicked()),this,SLOT(copyToClipboardButtonClicked()));
 }

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -35,7 +35,7 @@ This file is part of the QGROUNDCONTROL project
 #include "CommConfigurationWindow.h"
 #include "QGCWaypointListMulti.h"
 #include "MainWindow.h"
-#include "JoystickWidget.h"
+//#include "JoystickWidget.h"
 #include "GAudioOutput.h"
 #include "QGCToolWidget.h"
 #include "QGCMAVLinkLogPlayer.h"
@@ -261,9 +261,9 @@ MainWindow::MainWindow(QWidget *parent):
 #endif
 
     // Connect user interface devices
-    emit initStatusChanged("Initializing joystick interface.");
-    joystickWidget = 0;
-    joystick = new JoystickInput();
+    //emit initStatusChanged("Initializing joystick interface.");
+    //joystickWidget = 0;
+    //joystick = new JoystickInput();
 
 #ifdef MOUSE_ENABLED_WIN
     emit initStatusChanged("Initializing 3D mouse interface.");
@@ -384,6 +384,7 @@ MainWindow::~MainWindow()
 {
     closeTerminalConsole();
 
+    /*
     if (joystickWidget)
     {
         QLOG_DEBUG() << "Delete JoystickWidget";
@@ -398,6 +399,7 @@ MainWindow::~MainWindow()
         delete joystick;
         joystick = NULL;
     }
+    */
 
     // Get and delete all dockwidgets and contained
     // widgets
@@ -1738,7 +1740,7 @@ void MainWindow::connectCommonActions()
 
     // Configuration
     // Joystick
-    connect(ui.actionJoystickSettings, SIGNAL(triggered()), this, SLOT(configure()));
+    //connect(ui.actionJoystickSettings, SIGNAL(triggered()), this, SLOT(configure()));
     // Application Settings
     connect(ui.actionSettings, SIGNAL(triggered()), this, SLOT(showSettings()));
 
@@ -1807,6 +1809,7 @@ void MainWindow::showRoadMap()
 
 void MainWindow::configure()
 {
+    /*
     if (!joystickWidget)
     {
         if (!joystick->isRunning())
@@ -1816,6 +1819,7 @@ void MainWindow::configure()
         joystickWidget = new JoystickWidget(joystick);
     }
     joystickWidget->show();
+    */
 }
 
 void MainWindow::showSettings()

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -48,7 +48,7 @@ This file is part of the QGROUNDCONTROL project
 #include "UASControlWidget.h"
 #include "UASInfoWidget.h"
 #include "WaypointList.h"
-#include "CameraView.h"
+//#include "CameraView.h"
 #include "UASListWidget.h"
 //#include "MAVLinkProtocol.h"
 #include "MAVLinkSimulationLink.h"


### PR DESCRIPTION
After some slight changes, mostly commenting out, things are running with Qt 5.5.1 (and Qt 5.4.2) and MSVC2013 on Windows, both 32 and 64 bit compiling. Unfortunately she didn't like CameraView, Joystick, and Magellan 3D mouse includes (among a few other small things).

I tested with SITL on both Windows 7 and a virtual Ubuntu 14.04 and didn't notice anything strange (other than no camera or joystick stuff). I do not currently have access to OSX. I also don't have physical hardware right now to test uploading/calibrating/etc. Most of the changes came from what QGC is doing as they use Qt 5.5.1 and MSVC2013.

I don't want to step on any toes though as it seems @dcarpy is already doing some work with native windows builds and MSVC2012. If we want to go this direction I will then see about fixing the CameraView and Joystick includes. 

