### PR TITLE
Build: Windows compile work

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -49,7 +49,7 @@ linux-g++-64 {
          DEFINES += Q_UBUNTU
     }
 
-} else : win32-msvc2010 | win32-msvc2012 | win32-msvc2013 {
+} else : win32-msvc2012 | win32-msvc2013 {
     message(Windows build)
     CONFIG += WindowsBuild
 }  else : win32-g++|win64-g++ {

--- a/src/QGC.h
+++ b/src/QGC.h
@@ -34,8 +34,7 @@
 #define define2string_p(x) #x
 #define define2string(x) define2string_p(x)
 
-#ifdef _MSC_VER
-    #if _MSC_VER<1800
+#if defined(_MSC_VER) && (_MSC_VER<1800)
         #include <limits>
 
         template<typename T>
@@ -47,7 +46,6 @@
         inline bool isinf(T value){
             return (value == std::numeric_limits<T>::infinity() || (-1*value) == std::numeric_limits<T>::infinity()) && std::numeric_limits<T>::has_infinity;
         }
-    #endif
 #else
     #include <cmath>
 

--- a/src/QGC.h
+++ b/src/QGC.h
@@ -34,18 +34,20 @@
 #define define2string_p(x) #x
 #define define2string(x) define2string_p(x)
 
-#if defined(Q_OS_WIN) && (_MSC_VER<1800)
-    #include <limits>
+#ifdef _MSC_VER
+    #if _MSC_VER<1800
+        #include <limits>
 
-    template<typename T>
-    inline bool isnan(T value){
-        return value != value;
-    }
+        template<typename T>
+        inline bool isnan(T value){
+            return value != value;
+        }
 
-    template<typename T>
-    inline bool isinf(T value){
-        return (value == std::numeric_limits<T>::infinity() || (-1*value) == std::numeric_limits<T>::infinity()) && std::numeric_limits<T>::has_infinity;
-    }
+        template<typename T>
+        inline bool isinf(T value){
+            return (value == std::numeric_limits<T>::infinity() || (-1*value) == std::numeric_limits<T>::infinity()) && std::numeric_limits<T>::has_infinity;
+        }
+    #endif
 #else
     #include <cmath>
 


### PR DESCRIPTION
Change check from Q_OS_Win to looking if _MSC_VER is defined as the former causes build failing with MinGW. Also remove MSVC2010 from supported Windows compilers. 