### PR TITLE
Graph View: Bugfix: Log Export not complete. Fixes #796

### DIFF
--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -342,7 +342,7 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                     QLOG_DEBUG() << "AP2DataPlotThread::run(): ERROR UNKNOWN DATA TYPE" << typeCode;
                                 }
                             }
-                            if (valuepairlist.size() > 1)
+                            if (valuepairlist.size() >= 1)
                             {
                                 if (!m_dataModel->addRow(name,valuepairlist,index))
                                 {


### PR DESCRIPTION
Valuepairs were only stored if size was bigger than 1 but all non empty pairs need to be stored.
This fixes point 2 - The MSG line(s) is -not always- exported - mentioned in #796 

I was not able to reproduce the two other points 
* 1. - Defined are C1 to C14 but only C1 to C12 are exported
* 3. - Missing Parameters

Tested with ArduCopter V3.2.1

