### PR TITLE
Graph View: Speed up binary log parsing and log exporting.

### DIFF
--- a/src/ui/AP2DataPlot2D.cpp
+++ b/src/ui/AP2DataPlot2D.cpp
@@ -1500,21 +1500,29 @@ void AP2DataPlot2D::exportDialogAccepted()
             formatheader += line + "\r\n";
         }
     }
-
     outputfile.write(formatheader.toLatin1());
 
     for (int i=0;i<m_tableModel->rowCount();i++)
     {
         int j=1;
-        QVariant val = m_tableModel->data(m_tableModel->index(i,j++));
-        QString line = val.toString();
-        val = m_tableModel->data(m_tableModel->index(i,j++));
-        while (!val.isNull())
+        bool rowFetched = m_tableModel->prefetchRow(m_tableModel->index(i,j));
+
+        if (rowFetched)
         {
-            line += ", " + val.toString();
-            val = m_tableModel->data(m_tableModel->index(i,j++));
+            QVariant val = m_tableModel->dataFromPrefetchedRow(m_tableModel->index(i,j++));
+            QString line = val.toString();
+            val = m_tableModel->dataFromPrefetchedRow(m_tableModel->index(i,j++));
+            while (!val.isNull())
+            {
+                line += ", " + val.toString();
+                val = m_tableModel->dataFromPrefetchedRow(m_tableModel->index(i,j++));
+            }
+            outputfile.write(line.append("\r\n").toLatin1());
         }
-        outputfile.write(line.append("\r\n").toLatin1());
+        else
+        {
+            QLOG_DEBUG() << "AP2DataPlot2D::exportDialogAccepted: Row " << i << " could not be fetched.";
+        }
         if (i % 5)
         {
             progressDialog->setValue(100.0 * ((double)i / (double)m_tableModel->rowCount()));

--- a/src/ui/AP2DataPlot2DModel.cc
+++ b/src/ui/AP2DataPlot2DModel.cc
@@ -488,8 +488,8 @@ QVariant AP2DataPlot2DModel::data ( const QModelIndex & index, int role) const
 QVariant AP2DataPlot2DModel::dataFromPrefetchedRow(const QModelIndex &index)
 {
     // Check whether its the same row as used for the prefetch call
-    // and if size is at least 2
-    if ((index.row() == m_prefetchedRowIndex.row()) && m_prefetchedRowData.size() >= 2)
+    // and if size is at least 1
+    if ((index.row() == m_prefetchedRowIndex.row()) && (m_prefetchedRowData.size() >= 1))
     {
         if (index.column() == 0)
         {

--- a/src/ui/AP2DataPlot2DModel.h
+++ b/src/ui/AP2DataPlot2DModel.h
@@ -61,6 +61,25 @@ public:
     quint64 getLastIndex();
     quint64 getFirstIndex();
 
+    /**
+     * @brief Fetches the row defined in index and stores the values in
+     *        an internal structure for later usage
+     * @param index - defines the row which will be fetched and stored
+     * @return true if successful - false otherwise
+     */
+    bool prefetchRow(const QModelIndex& index);
+
+    /**
+     * @brief Reads the data from a previous prefetchRow(). Index must hold
+     *        the same row wich was used for the prefetch. The value referred
+     *        by colum will be returned.
+     * @param index - defines the colum wich will be returned. Row must be the
+     *                same used for prefetch.
+     * @return QVariant containing the data or empty QVariant if colum or row not
+     *         valid
+     */
+    QVariant dataFromPrefetchedRow(const QModelIndex& index);
+
 public slots:
     void selectedRowChanged(QModelIndex current,QModelIndex previous);
 
@@ -97,6 +116,9 @@ private:
 
     QSqlQuery *m_indexinsertquery;
     QSqlQuery *m_fmtInsertQuery;
+
+    QVector<QVariant> m_prefetchedRowData;  /// Stores the data fetched with prefetchRow(...)
+    QModelIndex m_prefetchedRowIndex;       /// Stores the index which was used for the last prefetchRow(...) call
 
 
 };

--- a/src/ui/AP2DataPlot2DModel.h
+++ b/src/ui/AP2DataPlot2DModel.h
@@ -72,7 +72,8 @@ public:
     /**
      * @brief Reads the data from a previous prefetchRow(). Index must hold
      *        the same row wich was used for the prefetch. The value referred
-     *        by colum will be returned.
+     *        by colum will be returned. If index is not valid an empty QVariant
+     *        will be returned.
      * @param index - defines the colum wich will be returned. Row must be the
      *                same used for prefetch.
      * @return QVariant containing the data or empty QVariant if colum or row not

--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -174,7 +174,7 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                         QString name = typeToNameMap.value(type);
                         if (tables.contains(name))
                         {
-                            QString linetoemit = typeToNameMap.value(type);
+                            //QString linetoemit = typeToNameMap.value(type);
                             index++;
                             QList<QPair<QString,QVariant> > valuepairlist;
                             QString formatstr = typeToFormatMap.value(type);
@@ -188,49 +188,49 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                 {
                                     qint8 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<qint8>(val));
+                                    //linetoemit += "," + QString::number(static_cast<qint8>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'B') //uint8_t
                                 {
                                     quint8 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<quint8>(val));
+                                    //linetoemit += "," + QString::number(static_cast<quint8>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'h') //int16_t
                                 {
                                     qint16 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<qint16>(val));
+                                    //linetoemit += "," + QString::number(static_cast<qint16>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'H') //uint16_t
                                 {
                                     quint16 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<quint16>(val));
+                                    //linetoemit += "," + QString::number(static_cast<quint16>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'i') //int32_t
                                 {
                                     qint32 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<qint32>(val));
+                                    //linetoemit += "," + QString::number(static_cast<qint32>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'I') //uint32_t
                                 {
                                     quint32 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<quint32>(val));
+                                    //linetoemit += "," + QString::number(static_cast<quint32>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'f') //float
                                 {
                                     float f;
                                     packetstream >> f;
-                                    linetoemit += "," + QString::number(f,'f',4);
+                                    //linetoemit += "," + QString::number(f,'f',4);
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),f));
                                 }
                                 else if (typeCode == 'n') //char(4)
@@ -246,7 +246,7 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                             val += static_cast<char>(ch);
                                         }
                                     }
-                                    linetoemit += "," + val;
+                                    //linetoemit += "," + val;
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'N') //char(16)
@@ -261,7 +261,7 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                             val += static_cast<char>(ch);
                                         }
                                     }
-                                    linetoemit += "," + val;
+                                    //linetoemit += "," + val;
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'Z') //char(64)
@@ -276,35 +276,35 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                             val += static_cast<char>(ch);
                                         }
                                     }
-                                    linetoemit += "," + val;
+                                    //linetoemit += "," + val;
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'c') //int16_t * 100
                                 {
                                     qint16 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number((val/100.0) , 'f', 4);
+                                    //linetoemit += "," + QString::number((val/100.0) , 'f', 4);
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val / 100.0));
                                 }
                                 else if (typeCode == 'C') //uint16_t * 100
                                 {
                                     quint16 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number((val/100.0) , 'f', 4);
+                                    //linetoemit += "," + QString::number((val/100.0) , 'f', 4);
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val / 100.0));
                                 }
                                 else if (typeCode == 'e') //int32_t * 100
                                 {
                                     qint32 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number((val/100.0) , 'f', 4);
+                                    //linetoemit += "," + QString::number((val/100.0) , 'f', 4);
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val / 100.0));
                                 }
                                 else if (typeCode == 'E') //uint32_t * 100
                                 {
                                     quint32 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number((val/100.0) , 'f', 4);
+                                    //linetoemit += "," + QString::number((val/100.0) , 'f', 4);
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val / 100.0));
                                 }
                                 else if (typeCode == 'L') //uint32_t GPS Lon/Lat * 10000000
@@ -312,28 +312,28 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                     qint32 val;
                                     packetstream >> val;
                                     double latLonValue = val/1e7;
-                                    linetoemit += "," + QString::number(latLonValue,'f',6);
+                                    //linetoemit += "," + QString::number(latLonValue,'f',6);
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val / 10000000.0));
                                 }
                                 else if (typeCode == 'M')
                                 {
                                     qint8 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<qint8>(val));
+                                    //linetoemit += "," + QString::number(static_cast<qint8>(val));
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'q')
                                 {
                                     qint64 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<qint64>(val));;
+                                    //linetoemit += "," + QString::number(static_cast<qint64>(val));;
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else if (typeCode == 'Q')
                                 {
                                     quint64 val;
                                     packetstream >> val;
-                                    linetoemit += "," + QString::number(static_cast<quint64>(val));;
+                                    //linetoemit += "," + QString::number(static_cast<quint64>(val));;
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val));
                                 }
                                 else
@@ -355,19 +355,31 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
 
                             if (type == paramtype && m_loadedLogType == MAV_TYPE_GENERIC)
                             {
-                                if (linetoemit.contains("RATE_RLL_P") || linetoemit.contains("H_SWASH_PLATE"))
+                                // Name field is not always on same Index. So first search for the right position...
+                                int nameIndex = 0;
+                                for (int i = 0; i < valuepairlist.size(); ++i)
+                                {
+                                    if (valuepairlist[i].first == "Name")
+                                    {
+                                        nameIndex = i;
+                                        break;
+                                    }
+                                }
+                                //...and then use it to check the values.
+                                if (valuepairlist[nameIndex].second == "RATE_RLL_P" || valuepairlist[nameIndex].second == "H_SWASH_PLATE")
                                 {
                                     m_loadedLogType = MAV_TYPE_QUADROTOR;
                                 }
-                                if (linetoemit.contains("PTCH2SRV_P"))
+                                else if (valuepairlist[nameIndex].second == "PTCH2SRV_P")
                                 {
                                     m_loadedLogType = MAV_TYPE_FIXED_WING;
                                 }
-                                if (linetoemit.contains("SKID_STEER_OUT"))
+                                else if (valuepairlist[nameIndex].second == "SKID_STEER_OUT")
                                 {
                                     m_loadedLogType = MAV_TYPE_GROUND_ROVER;
                                 }
                             }
+                            //QLOG_DEBUG() << linetoemit;
                         }
                         else
                         {
@@ -394,6 +406,7 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
         return;
     }
 }
+
 void AP2DataPlotThread::loadAsciiLog(QFile &logfile)
 {
     m_loadedLogType = MAV_TYPE_GENERIC;


### PR DESCRIPTION
While making tests for the last bugfix I recognized that the log export in Graph View was extremely slow. The root cause was excessive database access while exporting the logs.
I reduced the DB access by caching some data.
Furthermore I commented the log line formatting while parsing binary logs (gave a little speedup too).
Vehicle type detection is now done comparing values of the valuepairlist directly.
