### PR TITLE
Graph View: Speedup export and sort Fixes #864

### DIFF
--- a/src/ui/AP2DataPlot2D.cpp
+++ b/src/ui/AP2DataPlot2D.cpp
@@ -1466,6 +1466,8 @@ void AP2DataPlot2D::exportButtonClicked()
 }
 void AP2DataPlot2D::exportDialogAccepted()
 {
+    QElapsedTimer timer1;
+    timer1.start();
     QFileDialog *dialog = qobject_cast<QFileDialog*>(sender());
     if (!dialog)
     {
@@ -1505,24 +1507,15 @@ void AP2DataPlot2D::exportDialogAccepted()
     for (int i=0;i<m_tableModel->rowCount();i++)
     {
         int j=1;
-        bool rowFetched = m_tableModel->prefetchRow(m_tableModel->index(i,j));
-
-        if (rowFetched)
+        QVariant val = m_tableModel->data(m_tableModel->index(i,j++));
+        QString line = val.toString();
+        val = m_tableModel->data(m_tableModel->index(i,j++));
+        while (!val.isNull())
         {
-            QVariant val = m_tableModel->dataFromPrefetchedRow(m_tableModel->index(i,j++));
-            QString line = val.toString();
-            val = m_tableModel->dataFromPrefetchedRow(m_tableModel->index(i,j++));
-            while (!val.isNull())
-            {
-                line += ", " + val.toString();
-                val = m_tableModel->dataFromPrefetchedRow(m_tableModel->index(i,j++));
-            }
-            outputfile.write(line.append("\r\n").toLatin1());
+            line += ", " + val.toString();
+            val = m_tableModel->data(m_tableModel->index(i,j++));
         }
-        else
-        {
-            QLOG_DEBUG() << "AP2DataPlot2D::exportDialogAccepted: Row " << i << " could not be fetched.";
-        }
+        outputfile.write(line.append("\r\n").toLatin1());
         if (i % 5)
         {
             progressDialog->setValue(100.0 * ((double)i / (double)m_tableModel->rowCount()));
@@ -1543,6 +1536,8 @@ void AP2DataPlot2D::exportDialogAccepted()
     progressDialog->hide();
     progressDialog->deleteLater();
     progressDialog=NULL;
+
+    QLOG_DEBUG() << "Log export took " << timer1.elapsed() << "ms";
 
 }
 

--- a/src/ui/AP2DataPlot2D.h
+++ b/src/ui/AP2DataPlot2D.h
@@ -151,6 +151,13 @@ private:
     int getStatusTextPos();
     void plotTextArrow(int index, const QString& text, const QString& graph, QCheckBox *checkBox = NULL);
 
+    /**
+     * @brief This method disables the filtering of m_tableFilterProxyModel
+     *        After a call the table model will show all rows again.
+     */
+    void disableTableFilter();
+
+
 private:
     Ui::AP2DataPlot2D ui;
 

--- a/src/ui/AP2DataPlot2DModel.h
+++ b/src/ui/AP2DataPlot2DModel.h
@@ -61,26 +61,6 @@ public:
     quint64 getLastIndex();
     quint64 getFirstIndex();
 
-    /**
-     * @brief Fetches the row defined in index and stores the values in
-     *        an internal structure for later usage
-     * @param index - defines the row which will be fetched and stored
-     * @return true if successful - false otherwise
-     */
-    bool prefetchRow(const QModelIndex& index);
-
-    /**
-     * @brief Reads the data from a previous prefetchRow(). Index must hold
-     *        the same row wich was used for the prefetch. The value referred
-     *        by colum will be returned. If index is not valid an empty QVariant
-     *        will be returned.
-     * @param index - defines the colum wich will be returned. Row must be the
-     *                same used for prefetch.
-     * @return QVariant containing the data or empty QVariant if colum or row not
-     *         valid
-     */
-    QVariant dataFromPrefetchedRow(const QModelIndex& index);
-
 public slots:
     void selectedRowChanged(QModelIndex current,QModelIndex previous);
 
@@ -103,14 +83,16 @@ private:
     QString m_error;
     QString m_databaseName;
     QSqlDatabase m_sharedDb;
-    QMap<int,QPair<quint64,QString> > m_rowToTableMap;
+    QVector<QPair<quint64,QString> > m_rowIndexToDBIndex;   /// stores relation between Table row index
+                                                            /// and DB index and DB table name
     QMap<QString,QList<QString> > m_headerStringList;
     QList<QString> m_currentHeaderItems;
     QList<QList<QString> > m_fmtStringList;
 
     QMap<QString,queryPtr> m_msgNameToPrepearedInsertQuery;  /// Map holding prepared insert queries to speed up inserts
+    QMap<QString,queryPtr> m_msgNameToPrepearedSelectQuery;  /// Map holding prepared select queries to speed up selects
 
-    int m_rowCount;
+    int m_rowCount;         /// Stores the number of rows held in model.
     int m_columnCount;
     int m_currentRow;
     int m_fmtIndex;
@@ -121,8 +103,11 @@ private:
     queryPtr m_indexinsertquery;
     queryPtr m_fmtInsertQuery;
 
-    QVector<QVariant> m_prefetchedRowData;  /// Stores the data fetched with prefetchRow(...)
-    QModelIndex m_prefetchedRowIndex;       /// Stores the index which was used for the last prefetchRow(...) call
+    mutable QVector<QVariant> m_prefetchedRowData;  /// holds the cached data used in data(...) method
+    mutable QModelIndex m_prefetchedRowIndex;       /// Stores the index which which is actually in cache
+
+
+
 
 
 };


### PR DESCRIPTION
I migrated the new prefetch methods I introduced in a0578ba28b80cfafd021438cbbfb2f00b51aa911 into the old data method which will do the caching now. All functions using the data method will now benefit from the caching, not only the export feature.
Through using prepared select queries the log export got another boost. Exporting 36Mb logfile takes now round about 22 seconds.
Furthermore I tried to optimize the sorting feature. Due to a lack of knowledge about the internals of the QSortFilterProxyModel I did some erratic testing. The result can be seen below. I don't know if this is good QT style but on my Ubuntu 15.04 this solution gave the best performace on huge logs. My testing log was 15Mb binary one with round about 520000 loglines. All filter actions are now done in less than one second.
So test and have fun!!