### PR TITLE
Graph View: Better handling of corrupted logfiles Fixes #868

### DIFF
--- a/src/ui/AP2DataPlot2D.cpp
+++ b/src/ui/AP2DataPlot2D.cpp
@@ -1190,7 +1190,7 @@ void AP2DataPlot2D::threadDone(int errors,MAV_TYPE type)
 
     if (errors != 0)
     {
-        QMessageBox::information(this,"Warning","There were errors countered with " + QString::number(errors) + " lines in the log file. The data is potentially corrupt and incorrect");
+        QMessageBox::warning(this,"Warning","There were errors countered with " + QString::number(errors) + " lines in the log file. The data is potentially corrupt and incorrect");
     }
 
 


### PR DESCRIPTION
* Increased severity of popup window.
* Added handling for "not a number" while parsing binary logs.
* Make use of m_errorCount to feed back number of errors detected.