### PR TITLE
Graph View: Create more detailed error message on log loading

### DIFF
--- a/src/ui/AP2DataPlot2D.h
+++ b/src/ui/AP2DataPlot2D.h
@@ -85,7 +85,7 @@ private slots:
     //Cancel clicked on the graph loading thread progress dialog
     void progressDialogCanceled();
     //Graph loading thread finished
-    void threadDone(int errors,MAV_TYPE type);
+    void threadDone(AP2DataPlotStatus state, MAV_TYPE type);
     //Graph loading thread actually exited
     void threadTerminated();
     //Graph loading thread error

--- a/src/ui/AP2DataPlotThread.cc
+++ b/src/ui/AP2DataPlotThread.cc
@@ -310,7 +310,6 @@ void AP2DataPlotThread::loadBinaryLog(QFile &logfile)
                                 {
                                     qint32 val;
                                     packetstream >> val;
-                                    double latLonValue = val/1e7;
                                     valuepairlist.append(QPair<QString,QVariant>(labelstrsplit.at(j),val / 10000000.0));
                                 }
                                 else if (typeCode == 'M')

--- a/src/ui/AP2DataPlotThread.h
+++ b/src/ui/AP2DataPlotThread.h
@@ -37,6 +37,92 @@ This file is part of the APM_PLANNER project
 #include "AP2DataPlot2DModel.h"
 #include "libs/mavlink/include/mavlink/v1.0/ardupilotmega/mavlink.h"
 
+/**
+ * @brief The AP2DataPlotStatus class is a helper class desinged as status type for
+ *        the log parsing.
+ *        It contains the final state of parsing as well as all error strings inserted
+ *        with the corruptDataRead() or corruptFMTRead() methods during the parsing process.
+ */
+class AP2DataPlotStatus
+{
+public:
+
+    /**
+     * @brief The parsingState enum
+     *        All possible parsing states
+     */
+    enum parsingState
+    {
+        OK,                 /// Perfect result
+        FmtError,           /// Corrupt Format description.
+        TruncationError,    /// The log was truncated due to errors @ the end
+        DataError           /// Data can be corrupted or incomplete
+    };
+
+    /**
+     * @brief AP2DataPlotStatus CTOR
+     */
+    AP2DataPlotStatus();
+
+    /**
+     * @brief validDataRead
+     *        Shall be called if a logline was read successful. Used to
+     *        determine if the error(s) are only at the end of the log.
+     *        Should be inline due to the high calling frequency.
+     */
+    inline void validDataRead()
+    {
+        if (m_parsingState == TruncationError)
+        {
+            m_parsingState = DataError;
+        }
+    }
+
+    /**
+     * @brief corruptDataRead
+     *        Shall be called when ever an error occurs while parsing
+     *        a data package.
+     *
+     * @param index - The log index the error occured
+     * @param errorMessage - Error message describing the error reason
+     */
+    void corruptDataRead(const int index, const QString &errorMessage);
+
+    /**
+     * @brief corruptFMTRead
+     *        Shall be called when ever an error occurs while parsing
+     *        a format package.
+     *
+     * @param index - The log index the error occured
+     * @param errorMessage - Error message describing the error reason
+     */
+    void corruptFMTRead(const int index, const QString &errorMessage);
+
+    /**
+     * @brief getParsingState
+     *        Delivers the final state of the log parsing. The value
+     *        is only valid if parsing is finished.
+     *
+     * @return - The parsing state - @see parsingState
+     */
+    parsingState getParsingState();
+
+    /**
+     * @brief getErrorText
+     *        Creates a text containing all errormessages inserted during
+     *        parsing. One line for each error.
+     *
+     * @return - multi line string with all error messages.
+     */
+    QString getErrorText();
+
+private:
+    typedef QPair<int, QString> errorEntry; /// Type for storing error index and text
+    parsingState m_parsingState;            /// The internal parsing state
+    QVector<errorEntry> m_errors;           /// For storing all error entries
+};
+
+
 class AP2DataPlotThread : public QThread
 {
     Q_OBJECT
@@ -51,7 +137,7 @@ signals:
     void startLoad();
     void loadProgress(qint64 pos,qint64 size);
     void payloadDecoded(int index,QString name,QVariantMap map);
-    void done(int errors,MAV_TYPE type);
+    void done(AP2DataPlotStatus state,MAV_TYPE type);
     void error(QString errorstr);
     void lineRead(QString line);
 
@@ -68,12 +154,17 @@ private:
     QString m_fileName;
     bool m_stop;
     int m_fieldCount;
-    int m_errorCount;
+//    int m_errorCount;
     MAV_TYPE m_loadedLogType;
     MAVLinkDecoder *m_decoder;
     AP2DataPlot2DModel *m_dataModel;
     QMap<QString,QString> m_msgNameToInsertQuery;
     quint64 m_logStartTime;
+
+    AP2DataPlotStatus m_plotState;
 };
+
+
+
 
 #endif // AP2DATAPLOTTHREAD_H

--- a/src/ui/AP2DataPlotThread.h
+++ b/src/ui/AP2DataPlotThread.h
@@ -154,7 +154,6 @@ private:
     QString m_fileName;
     bool m_stop;
     int m_fieldCount;
-//    int m_errorCount;
     MAV_TYPE m_loadedLogType;
     MAVLinkDecoder *m_decoder;
     AP2DataPlot2DModel *m_dataModel;


### PR DESCRIPTION
As discussed in #868 here is my solution for providing more details about errors raised during log parsing. Hope you like it. If you have any Ideas for better messages or anything else - just let me know.
By the way - I was not able to resize the message box setFixedSize() did not work as expected. It would be good to increase the width.
This is what it looks like now:
![new_error_popup1](https://cloud.githubusercontent.com/assets/7621911/12373732/8455d038-bc83-11e5-88de-1201bc8361e5.png)
![new_error_popup2](https://cloud.githubusercontent.com/assets/7621911/12373733/86d6060c-bc83-11e5-930e-a5ab79bbcc66.png)
![new_error_popup3](https://cloud.githubusercontent.com/assets/7621911/12373734/89b33d04-bc83-11e5-978c-e1c0595465a2.png)

By the way during developing I foud out that most of my APM 3.2.1 binary logs have an error during format parsing.