### PR TITLE
Graph View: Crash fixing and restructuring of TLOG parsing

### DIFF
--- a/src/ui/AP2DataPlot2D.cpp
+++ b/src/ui/AP2DataPlot2D.cpp
@@ -170,10 +170,8 @@ AP2DataPlot2D::AP2DataPlot2D(QWidget *parent,bool isIndependant) : QWidget(paren
 
     ui.horizontalSplitter->setStretchFactor(0,20);
     ui.horizontalSplitter->setStretchFactor(1,1);
-
-    qRegisterMetaType<AP2DataPlotStatus>("AP2DataPlotStatus");
-
 }
+
 void AP2DataPlot2D::setExcelViewHidden(bool hidden)
 {
     if (hidden)
@@ -1411,9 +1409,12 @@ void AP2DataPlot2D::threadDone(AP2DataPlotStatus state, MAV_TYPE type)
 void AP2DataPlot2D::threadError(QString errorstr)
 {
     QMessageBox::information(0,"Error",errorstr);
-    m_progressDialog->hide();
-    delete m_progressDialog;
-    m_progressDialog=0;
+    if (m_progressDialog)
+    {
+        m_progressDialog->hide();
+        delete m_progressDialog;
+        m_progressDialog=0;
+    }
     ui.dataSelectionScreen->clear();
     m_dataList.clear();
 }

--- a/src/ui/AP2DataPlotThread.h
+++ b/src/ui/AP2DataPlotThread.h
@@ -153,12 +153,10 @@ private:
 private:
     QString m_fileName;
     bool m_stop;
-    int m_fieldCount;
     MAV_TYPE m_loadedLogType;
-    MAVLinkDecoder *m_decoder;
+    QSharedPointer<MAVLinkDecoder> m_decoder;
     AP2DataPlot2DModel *m_dataModel;
     QMap<QString,QString> m_msgNameToInsertQuery;
-    quint64 m_logStartTime;
 
     AP2DataPlotStatus m_plotState;
 };


### PR DESCRIPTION
While doing some test I noticed that Tlog parsing is very slow and fails sometimes which leads to a segfault due to null-pointer access. So I fixed this and restructured the tlog parsing. This is the result.

* Heavy restructuring of TLOG parsing:
  - removed several memleaks and switched to shared pointer
  - removed time handling cause using it as index lead to DB errors
  - improoved errorhandling uses m_plotState now
  - introduced filtering of "EMPTY" messages as they have no format info

* Moved metatype registration to AP2DataPlotThread class
* Fixed null pointer access in AP2DataPlot2D::threadError