### PR TITLE
Graph View: Support for plotting data vs. time if all data has microsec timestamp

### DIFF
--- a/src/ui/AP2DataPlot2D.h
+++ b/src/ui/AP2DataPlot2D.h
@@ -131,6 +131,7 @@ private slots:
     void modeCheckBoxClicked(bool checked);
     void errCheckBoxClicked(bool checked);
     void evCheckBoxClicked(bool checked);
+    void indexTypeCheckBoxClicked(bool checked);
     void sortItemChanged(QTreeWidgetItem* item,int col);
     void sortAcceptClicked();
     void sortCancelClicked();
@@ -151,11 +152,38 @@ private:
     int getStatusTextPos();
     void plotTextArrow(int index, const QString& text, const QString& graph, QCheckBox *checkBox = NULL);
 
+
     /**
      * @brief This method disables the filtering of m_tableFilterProxyModel
      *        After a call the table model will show all rows again.
      */
     void disableTableFilter();
+
+    /**
+     * @brief setupXAxisAndScroller sets up x axis and the horizontal scroller
+     *        to use the normal index (the artifical) or the time index regarding
+     *        to the value of m_useTimeOnX.
+     */
+    void setupXAxisAndScroller();
+
+    /**
+     * @brief removeTextArrows removes all text arrows of type graphName
+     *
+     * @param graphName - Name of the graph whose test arrows shall be removed
+     */
+    void removeTextArrows(const QString &graphName);
+
+    /**
+     * @brief insertModeArrows inserts mode text arrows into the graph
+     *        Uses normal or time index regarding of the value of m_useTimeOnX
+     */
+    void insertModeArrows();
+
+    /**
+     * @brief insertErrArrows inserts error text arrows into the graph
+     *        Uses normal or time index regarding of the value of m_useTimeOnX
+     */
+    void insertErrArrows();
 
 
 private:
@@ -173,6 +201,8 @@ private:
         QCPGraph *graph;
         QList<QCPAbstractItem*> itemList;
         QMap<double,QString> modeMap;
+
+        Graph() : isManualRange(false), isInGroup(false), axisIndex(0), axis(NULL), graph(NULL){}
     };
 
     QMap<QString,Graph> m_graphClassMap;
@@ -202,25 +232,24 @@ private:
     QCustomPlot *m_plot;
     QCPAxisRect *m_wideAxisRect;
     AP2DataPlotThread *m_logLoaderThread;
-    //DataSelectionScreen *m_dataSelectionScreen;
-    QStandardItemModel *m_model;
     bool m_logLoaded;
     //Current "index", X axis on graph. Used to keep all the graphs lined up.
     qint64 m_currentIndex;
     qint64 m_startIndex; //epoch msecs since graphing started
     QAction *m_addGraphAction;
     UASInterface *m_uas;
-    QProgressDialog *m_progressDialog;
+    QSharedPointer<QProgressDialog> m_progressDialog;
     AP2DataPlotAxisDialog *m_axisGroupingDialog;
     //qint64 m_timeDiff;
     bool m_tlogReplayEnabled;
-
 
     qint64 m_scrollStartIndex; //Actual graph start
     qint64 m_scrollEndIndex; //Actual graph end
 
     LogDownloadDialog *m_logDownloadDialog;
     DroneshareUploadDialog *m_droneshareUploadDialog;
+
+    bool m_useTimeOnX;  /// True if x axis uses time index
 
     MAV_TYPE m_loadedLogMavType;
 

--- a/src/ui/AP2DataPlot2D.ui
+++ b/src/ui/AP2DataPlot2D.ui
@@ -124,6 +124,19 @@
                 </property>
                </spacer>
               </item>
+              <item>
+               <widget class="QCheckBox" name="indexTypeCheckBox">
+                <property name="toolTip">
+                 <string extracomment="Switches between index or time on x axis"/>
+                </property>
+                <property name="toolTipDuration">
+                 <number>3</number>
+                </property>
+                <property name="text">
+                 <string>Use time on x-axis</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>

--- a/src/ui/AP2DataPlotThread.h
+++ b/src/ui/AP2DataPlotThread.h
@@ -151,12 +151,13 @@ private:
     void loadTLog(QFile &logfile);
 
 private:
+    static const QString timeStampSearchKey;    /// Search Key when searching for timestamps
+
     QString m_fileName;
     bool m_stop;
     MAV_TYPE m_loadedLogType;
     QSharedPointer<MAVLinkDecoder> m_decoder;
     AP2DataPlot2DModel *m_dataModel;
-    QMap<QString,QString> m_msgNameToInsertQuery;
 
     AP2DataPlotStatus m_plotState;
 };

--- a/src/ui/dataselectionscreen.cpp
+++ b/src/ui/dataselectionscreen.cpp
@@ -91,6 +91,12 @@ void DataSelectionScreen::disableItem(QString name)
     QLOG_ERROR() << "No item found in DataSelectionScreen:disableItem:" << name;
 }
 
+void DataSelectionScreen::disableAllItems()
+{
+    // Its like perssing the button
+    clearSelectionButtonClicked();
+}
+
 void DataSelectionScreen::addItem(QString name)
 {
     if (name.contains(":"))

--- a/src/ui/dataselectionscreen.h
+++ b/src/ui/dataselectionscreen.h
@@ -15,12 +15,14 @@ public:
 	void clear();
     void enableItem(QString name);
     void disableItem(QString name);
+    void disableAllItems();
 signals:
 	void itemEnabled(QString name);
 	void itemDisabled(QString name);
 private slots:
-    void onItemChanged(QTreeWidgetItem* item,int column);
     void clearSelectionButtonClicked();
+    void onItemChanged(QTreeWidgetItem* item,int column);
+
 private:
     QMap<QString,QString> m_nameToSysId;
     QList<QWidget*> m_itemList;


### PR DESCRIPTION
All data in Graph View is plotted against an artificial data index. This is a robust solution as not all logs support a valid time-line but it makes data matching against flight time impossible.

Since arducopter 3.3 all bin logs have a microsec time stamp on every value. So I thought it should be possible to plot the data vs. time and not only vs. index if the log has a valid time-line.
After a lot of work (you know the first feature prototype takes only 20% of the time the whole feature takes) I have made it. if there is a valid time-line you can switch between time or index on x axis, if not the check-box for switching is hidden.

I made 2 screenshots where you can see nearly the same data. First one shows data vs. time and the second shows data vs. index. The plot vs. time looks far better and more natural.
![timeline](https://cloud.githubusercontent.com/assets/7621911/12518273/f1595598-c137-11e5-85b1-627cd77370c5.png)
![timeline2](https://cloud.githubusercontent.com/assets/7621911/12518302/2a4fe04c-c138-11e5-9612-05f068dc40f1.png)

Changes overview:
* Added checkbox to switch between data vs. time and data vs. index
* Added several helper functions to avoid code doubling
* Fixed crash on load log canceling
* Removed some mem leaks
* Extended AP2DataPlot2DModel to support time indexes
* Cleanup and commenting