### PR TITLE
QT Styles: QToolTip visibility

### DIFF
--- a/files/styles/style-indoor.css
+++ b/files/styles/style-indoor.css
@@ -22,7 +22,6 @@ QSplitter::handle:vertical {
 QToolTip {
     background-color: #3D5368;
     border: 0px solid #379AC3;
-    margin: 3px;
     border-radius: 3px;
     color: #DDDDDF;
 }


### PR DESCRIPTION
In indoor-styles, some qtooltips are not fully visible
fixes bug #209
tested on linux and mac