### PR TITLE
EKF Monitor, Vibration Monitor: fix for ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Be sure to run apt-get update first
 sudo apt-get update
 sudo apt-get install qt5-qmake qt5-default \
   qtscript5-dev libqt5webkit5-dev libqt5serialport5-dev \
-  libqt5svg5-dev qtdeclarative5-qtquick2-plugin
+  libqt5svg5-dev qtdeclarative5-qtquick2-plugin qtdeclarative5-controls-plugin
 sudo apt-get install git libsdl1.2-dev  libsndfile-dev \
   flite1-dev libssl-dev libudev-dev libsdl2-dev
 ```

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: science
 Priority: extra
 Maintainer: APM Planner Developers <stephen_dade@hotmail.com>
 Vcs-Git: git://git.github.org/diydrones/apm_planner.git
-Build-Depends: git-buildpackage, debhelper, phonon, qt5-qmake, libqt5gui5, libqt5multimedia5, libqt5network5, libqt5opengl5-dev, libqt5positioning5, libqt5printsupport5, libqt5qml5, libqt5quick5, libqt5script5, libqt5svg5, libqt5sql5, libqt5webkit5, libqt5webkit5-qmlwebkitplugin | qml-module-qtwebkit, libqt5widgets5, libqt5xml5, libqt5declarative5, qtcreator, libsdl1.2-dev, libflite1, flite1-dev, build-essential, libopenscenegraph-dev, libssl-dev, libudev-dev, libc6, git, libsndfile1-dev, qt5-default, qtscript5-dev, libqt5webkit5-dev, libqt5serialport5-dev, libqt5svg5-dev, libsdl2-dev
+Build-Depends: git-buildpackage, debhelper, phonon, qt5-qmake, libqt5gui5, libqt5multimedia5, libqt5network5, libqt5opengl5-dev, libqt5positioning5, libqt5printsupport5, libqt5qml5, libqt5quick5, libqt5script5, libqt5svg5, libqt5sql5, libqt5webkit5, libqt5webkit5-qmlwebkitplugin | qml-module-qtwebkit, libqt5widgets5, libqt5xml5, libqt5declarative5, qtcreator, libsdl1.2-dev, libflite1, flite1-dev, build-essential, libopenscenegraph-dev, libssl-dev, libudev-dev, libc6, git, libsndfile1-dev, qt5-default, qtscript5-dev, libqt5webkit5-dev, libqt5serialport5-dev, libqt5svg5-dev, libsdl2-dev, qtdeclarative5-controls-plugin
 Homepage: https://github.com/diydrones/apm_planner
 Standards-Version: 3.9.4
 

--- a/qml/components/BarGauge.qml
+++ b/qml/components/BarGauge.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
 
 Rectangle {
     id: root


### PR DESCRIPTION
QtQuick.Controls 1.1
depends on qtdeclarative5-controls-plugin

note:
* not sure how to deal with platforms that have QtQuick.Controls 1.2 ?