### PR TITLE
build: generate exec and icon paths in desktop entry dynamically.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,5 +861,10 @@ if(UNIX AND NOT APPLE)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/files DESTINATION share/APMPlanner2)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/data DESTINATION share/APMPlanner2)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/qml DESTINATION share/APMPlanner2)
+    configure_file(
+        ${CMAKE_SOURCE_DIR}/common/apmplanner2.desktop.in
+        ${CMAKE_SOURCE_DIR}/common/apmplanner2.desktop
+        @ONLY
+    )
     install(FILES ${CMAKE_SOURCE_DIR}/common/apmplanner2.desktop DESTINATION share/applications)
 endif()

--- a/common/apmplanner2.desktop.in
+++ b/common/apmplanner2.desktop.in
@@ -2,9 +2,9 @@
 Type=Application
 Name=APM Planner 2
 GenericName=apmplanner2
-Exec=/usr/bin/apmplanner2
+Exec=@CMAKE_INSTALL_PREFIX@/bin/apmplanner2
 Terminal=false
 Categories=Education;Robotics;
 Comment=An open-source ground station application for MAVlink based autopilots
-Icon=/usr/share/APMPlanner2/files/APMIcons/ap_rc.png
+Icon=@CMAKE_INSTALL_PREFIX@/share/APMPlanner2/files/APMIcons/ap_rc.png
 


### PR DESCRIPTION
`make install` installs files to `/usr/local/bin` and `/usr/local/share` but [apmplanner2.desktop](https://github.com/ArduPilot/apm_planner/blob/master/common/apmplanner2.desktop) points to `/usr/bin/apmplanner2` and `/usr/share/APMPlanner2/files/APMIcons/ap_rc.png`. Thus, on Ubuntu 24.xx and 22.xx, desktop entries needed manual fixing after installation (make install or ninja install).

PR fixes this issue by templating the apmplanner2.desktop.