### PR TITLE
docs: use brew --prefix for macOS CMake Qt path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ cd apm_planner
 mkdir build
 cd build
 cmake -G Ninja .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5);$(brew --prefix)"
+ninja
+```
+
+Once the build finishes, the app bundle is created in the `build` directory. Launch it with:
+
+```
+open apmplanner2.app
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ git clone https://github.com/ArduPilot/apm_planner.git
 cd apm_planner
 mkdir build
 cd build
-cmake cmake -G Ninja .. -DCMAKE_PREFIX_PATH="/opt/homebrew/Cellar/qt@5/5.15.16_2;/opt/homebrew"
+cmake -G Ninja .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5);$(brew --prefix)"
 ```
 
 


### PR DESCRIPTION
Updates the macOS CMake build instructions in the README to resolve the Qt path dynamically via Homebrew instead of hardcoding a version-specific Cellar path.

```
cmake -G Ninja .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5);$(brew --prefix)"
```

Also adds missing instructions to build and open app.
